### PR TITLE
try to fix security problem

### DIFF
--- a/scripts-available/CDB_QueryTables.sql
+++ b/scripts-available/CDB_QueryTables.sql
@@ -16,6 +16,11 @@ BEGIN
 
   FOR rec IN SELECT CDB_QueryStatements(query) q LOOP
 
+    IF NOT ( rec.q ilike 'select%' or rec.q ilike 'with%' ) THEN
+        --RAISE WARNING 'Skipping %', rec.q;
+        CONTINUE;
+    END IF;
+
     BEGIN
       EXECUTE 'EXPLAIN (FORMAT XML, VERBOSE) ' || rec.q INTO STRICT exp;
     EXCEPTION WHEN others THEN

--- a/scripts-available/CDB_QueryTables.sql
+++ b/scripts-available/CDB_QueryTables.sql
@@ -16,11 +16,6 @@ BEGIN
 
   FOR rec IN SELECT CDB_QueryStatements(query) q LOOP
 
-    IF NOT ( rec.q ilike 'select %' or rec.q ilike 'with %' ) THEN
-      --RAISE WARNING 'Skipping %', rec.q;
-      CONTINUE;
-    END IF;
-
     BEGIN
       EXECUTE 'EXPLAIN (FORMAT XML, VERBOSE) ' || rec.q INTO STRICT exp;
     EXCEPTION WHEN others THEN

--- a/test/CDB_QueryTablesTest.sql
+++ b/test/CDB_QueryTablesTest.sql
@@ -31,3 +31,7 @@ create table sc.test (a int);
 insert into sc.test values (1);
 WITH inp AS ( select 'select * from sc.test'::text as q )
  SELECT q, CDB_QueryTables(q) from inp;
+
+WITH inp AS ( select 'SELECT
+* FROM geometry_columns'::text as q )
+ SELECT q, CDB_QueryTables(q) from inp;

--- a/test/CDB_QueryTablesTest_expect
+++ b/test/CDB_QueryTablesTest_expect
@@ -13,3 +13,5 @@ CREATE SCHEMA
 CREATE TABLE
 INSERT 0 1
 select * from sc.test|{sc.test}
+SELECT
+* FROM geometry_columns|{pg_catalog.pg_attribute,pg_catalog.pg_class,pg_catalog.pg_namespace,pg_catalog.pg_type}


### PR DESCRIPTION
a query like:

```
select cdb_querytables("select\n* from pg_class")
```

returns an empty set. That means that SQL API can't check if an user is selecting data from pg_class or other system tables (which is forbidden)

Removing that regexp check and letting postgres to do its work in the EXPLAIN makes it work.

I'm wondering if we could remove permissions to system tables to publicuser.

The problem with this PR is that changes the way cdb_querytables work. Right now if you do:

```
select cdb_querytables('create table (a int)')
```
it returns [] because the "ilike select %" hack removes the create table statement. 

Questions:

- is there a way to know if a query will write?
- any solution to this?

cc @pramsey @rochoa @Kartones @zenitraM 