### PR TITLE
Call PG has_table_privilege() with 'publicuser', not 'public'

### DIFF
--- a/scripts-available/CDB_UserTables.sql
+++ b/scripts-available/CDB_UserTables.sql
@@ -21,7 +21,7 @@ AS $$
       'spatial_ref_sys'
      )
   ), perms AS (
-    SELECT t, has_table_privilege('public', 'public'||'.'||t, 'SELECT') as p
+    SELECT t, has_table_privilege('publicuser', 'public'||'.'||t, 'SELECT') as p
     FROM usertables
   )
   SELECT t FROM perms


### PR DESCRIPTION
Before, you were using 'public', which reflects the CartoDB nomenclature for public tables. However, the has_table_privilege() function is from PostGRES, and it expects 'publicuser'.

The schema 'public' is still correct, since the schema is defined by the CartoDB-style naming pattern.

I believe you will find that
`SELECT CDB_UserTables('public')`
currently returns an empty set, but will return valid results after this patch.