### PR TITLE
CDB_QuantileBins.sql

### DIFF
--- a/scripts-available/CDB_QuantileBins.sql
+++ b/scripts-available/CDB_QuantileBins.sql
@@ -18,12 +18,12 @@ BEGIN
     -- get our unique values
     SELECT array_agg(e) INTO in_array FROM (SELECT unnest(in_array) e GROUP BY e ORDER BY e ASC) x;
     -- get the total size of our row
-    element_count := array_upper(in_array, 1) - array_lower(in_array, 1); 
+    element_count := array_length(in_array, 1); 
     break_size :=  element_count::numeric / breaks;
     -- slice our bread
     LOOP  
         IF i > breaks THEN  EXIT;  END IF;  
-        SELECT e INTO tmp_val FROM ( SELECT unnest(in_array) e LIMIT 1 OFFSET round(break_size * i)) x;
+        SELECT e INTO tmp_val FROM ( SELECT unnest(in_array) e LIMIT 1 OFFSET round(break_size * i) - 1) x;
         reply = array_append(reply, tmp_val);
         i := i+1; 
     END LOOP; 


### PR DESCRIPTION
The total size of array is calculated incorrectly. The current operation return a value equal to length of array minus one.
In order to correct this issue, we can to use the array length function, this function return the correct length value.
Below i show some samples using the same array for compare both functions:
SELECT CDB_QuantileBins(ARRAY[1,2,3,4,5,6,7,8,9,10,11,12], Q)

Current function:
Q = 3

Return value |  5  | 8 | 12
 ------------- | ------------- | ------------- | -------------
Quantile Bin| 1,2,3,4,5 | 6,7,8 | 9,10,11,12  

Q = 4

Return value |  4  | 7 | 9 | 12
 ------------- | ------------- | ------------- | -------------| -------------
Quantile Bin| 1,2,3,4 | 5,6,7 | 8,9 | 10,11,12  

Q = 5

Return value |  3  | 5 | 8| 10 |12
 ------------- | ------------- | ------------- | -------------| -------------| -------------
Quantile Bin| 1,2,3 | 4,5 | 6,7,8 |9,10 |11,12 

Proposal function:
Q = 3

Return value |  4  | 8 | 12
 ------------- | ------------- | ------------- | -------------
Quantile Bin| 1,2,3,4 | 5,6,7,8 | 9,10,11,12  

Q = 4

Return value |  3  | 6 | 9 | 12
 ------------- | ------------- | ------------- | -------------| -------------
Quantile Bin| 1,2,3 | 4,5,6 | 7,8,9 | 10,11,12  

Q = 5

Return value |  2  | 5 | 7| 10 |12
 ------------- | ------------- | ------------- | -------------| -------------| -------------
Quantile Bin| 1,2 | 3,4,5 | 6,7 | 8,9,10 |11,12 