### PR TITLE
Add a new function CDB_QueryTablesText #86

### DIFF
--- a/scripts-available/CDB_QueryTables.sql
+++ b/scripts-available/CDB_QueryTables.sql
@@ -2,12 +2,12 @@
 --
 -- Requires PostgreSQL 9.x+
 --
-CREATE OR REPLACE FUNCTION CDB_QueryTablesRegclass(query text)
-RETURNS regclass[]
+CREATE OR REPLACE FUNCTION CDB_QueryTablesText(query text)
+RETURNS text[]
 AS $$
 DECLARE
   exp XML;
-  tables regclass[];
+  tables text[];
   rec RECORD;
   rec2 RECORD;
 BEGIN
@@ -45,7 +45,7 @@ BEGIN
     LOOP
       -- RAISE DEBUG 'tab: %', rec2.p;
       -- RAISE DEBUG 'sc: %', rec2.sc;
-      tables := array_append(tables, (rec2.sc || '.' || rec2.p)::regclass);
+      tables := array_append(tables, (rec2.sc || '.' || rec2.p));
     END LOOP;
 
     -- RAISE DEBUG 'Tables: %', tables;
@@ -73,6 +73,6 @@ CREATE OR REPLACE FUNCTION CDB_QueryTables(query text)
 RETURNS name[]
 AS $$
 BEGIN
-  RETURN CDB_QueryTablesRegclass(query)::name[];
+  RETURN CDB_QueryTablesText(query)::name[];
 END
 $$ LANGUAGE 'plpgsql' VOLATILE STRICT;

--- a/scripts-available/CDB_QueryTables.sql
+++ b/scripts-available/CDB_QueryTables.sql
@@ -2,12 +2,12 @@
 --
 -- Requires PostgreSQL 9.x+
 --
-CREATE OR REPLACE FUNCTION CDB_QueryTables(query text)
-RETURNS name[]
+CREATE OR REPLACE FUNCTION CDB_QueryTablesRegclass(query text)
+RETURNS regclass[]
 AS $$
 DECLARE
   exp XML;
-  tables NAME[];
+  tables regclass[];
   rec RECORD;
   rec2 RECORD;
 BEGIN
@@ -41,11 +41,11 @@ BEGIN
           xpath('//x:Relation-Name/text()', exp, ARRAY[ARRAY['x', 'http://www.postgresql.org/2009/explain']]) as x,
           xpath('//x:Relation-Name/../x:Schema/text()', exp, ARRAY[ARRAY['x', 'http://www.postgresql.org/2009/explain']]) as s
       )
-      SELECT unnest(x)::name as p, unnest(s)::name as sc from inp
+      SELECT unnest(x) as p, unnest(s) as sc from inp
     LOOP
       -- RAISE DEBUG 'tab: %', rec2.p;
       -- RAISE DEBUG 'sc: %', rec2.sc;
-      tables := array_append(tables, (rec2.sc || '.' || rec2.p)::name);
+      tables := array_append(tables, (rec2.sc || '.' || rec2.p)::regclass);
     END LOOP;
 
     -- RAISE DEBUG 'Tables: %', tables;
@@ -63,5 +63,16 @@ BEGIN
   --RAISE DEBUG 'Tables: %', tables;
 
   return tables;
+END
+$$ LANGUAGE 'plpgsql' VOLATILE STRICT;
+
+
+-- Keep CDB_QueryTables with same signature for backwards compatibility.
+-- It should probably be removed in the future.
+CREATE OR REPLACE FUNCTION CDB_QueryTables(query text)
+RETURNS name[]
+AS $$
+BEGIN
+  RETURN CDB_QueryTablesRegclass(query)::name[];
 END
 $$ LANGUAGE 'plpgsql' VOLATILE STRICT;

--- a/test/CDB_QueryTablesTest_expect
+++ b/test/CDB_QueryTablesTest_expect
@@ -1,4 +1,3 @@
-\set ECHO none
 SELECT * FROM geometry_columns|{pg_catalog.pg_attribute,pg_catalog.pg_class,pg_catalog.pg_namespace,pg_catalog.pg_type}
 SELECT a.attname FROM pg_class c JOIN pg_attribute a on (a.attrelid = c.oid)|{pg_catalog.pg_attribute,pg_catalog.pg_class}
 CREATE table "my'tab;le" as select 1|{}

--- a/test/CDB_QueryTablesTest_expect
+++ b/test/CDB_QueryTablesTest_expect
@@ -1,13 +1,18 @@
+\set ECHO none
 SELECT * FROM geometry_columns|{pg_catalog.pg_attribute,pg_catalog.pg_class,pg_catalog.pg_namespace,pg_catalog.pg_type}
 SELECT a.attname FROM pg_class c JOIN pg_attribute a on (a.attrelid = c.oid)|{pg_catalog.pg_attribute,pg_catalog.pg_class}
 CREATE table "my'tab;le" as select 1|{}
 SELECT a.oid, b.oid FROM pg_class a, pg_class b|{pg_catalog.pg_class}
 SELECT 1 as col1; select 2 as col2|{}
 WARNING:  CDB_QueryTables cannot explain query: select 1 from nonexistant (42P01: relation "nonexistant" does not exist)
+CONTEXT:  PL/pgSQL function cdb_querytables(text) line 3 at RETURN
 ERROR:  relation "nonexistant" does not exist
+CONTEXT:  PL/pgSQL function cdb_querytables(text) line 3 at RETURN
 begin; select * from pg_class; commit;|{pg_catalog.pg_class}
 WARNING:  CDB_QueryTables cannot explain query: select * from test (42P01: relation "test" does not exist)
+CONTEXT:  PL/pgSQL function cdb_querytables(text) line 3 at RETURN
 ERROR:  relation "test" does not exist
+CONTEXT:  PL/pgSQL function cdb_querytables(text) line 3 at RETURN
 WITH a AS (select * from pg_class) select * from a|{pg_catalog.pg_class}
 CREATE SCHEMA
 CREATE TABLE


### PR DESCRIPTION
The return values of it can be safely used when len(schema.table_name)
exceeds the 63 char limit of the postgres type `name`.

@rochoa please review