### PR TITLE
Fix versioning by creating a 0.8.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # cartodb/Makefile
 
 EXTENSION = cartodb
-EXTVERSION = 0.7.4
+EXTVERSION = 0.8.0
 
 SED = sed
 
@@ -38,6 +38,7 @@ UPGRADABLE = \
   0.7.1 \
   0.7.2 \
   0.7.3 \
+  0.7.4 \
   $(EXTVERSION)dev \
   $(EXTVERSION)next \
   $(END)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-0.7.4 (2015-06-29)
+0.8.0 (2015-06-30)
 ------------------
 * Adds new function CDB_QueryTablesText that can deal with "schema.table_name"
   longer than 63 chars.
@@ -6,6 +6,10 @@
   - CDB_DistType
   - CDB_DistinctMeasure
   - CDB_EqualIntervalBins
+
+0.7.4 (2015-06-29)
+------------------
+Dummy transitional version.
 
 0.7.3 (2015-03-03)
 ------------------


### PR DESCRIPTION
Fix versioning by creating a new major version since it contains new
features. Keep version 0.7.4 that should've never existed and provide an
upgrade path for the new version.

@rochoa can you please review?