### PR TITLE
Fix for upgrade issue from 0.7.4 to 0.8.0

### DIFF
--- a/scripts-available/CDB_UserTables.sql
+++ b/scripts-available/CDB_UserTables.sql
@@ -5,6 +5,7 @@
 --
 -- Currently accepted permissions are: 'public', 'private' or 'all'
 --
+DROP FUNCTION IF EXISTS cdb_usertables(text);
 CREATE OR REPLACE FUNCTION CDB_UserTables(perm text DEFAULT 'all')
 RETURNS SETOF name
 AS $$


### PR DESCRIPTION
This fixes the following problem found during testing:
```
ALTER EXTENSION cartodb UPDATE TO '0.8.0';
ERROR:  cannot change return type of existing function
HINT:  Use DROP FUNCTION cdb_usertables(text) first.
```
cc/ @pramsey @rochoa 