### PR TITLE
Improve cartodb._CDB_total_relation_size performance

### DIFF
--- a/scripts-available/CDB_Quota.sql
+++ b/scripts-available/CDB_Quota.sql
@@ -1,18 +1,15 @@
 CREATE OR REPLACE FUNCTION cartodb._CDB_total_relation_size(_schema_name TEXT, _table_name TEXT)
 RETURNS bigint AS
 $$
+DECLARE relation_size bigint := 0;
 BEGIN
-  IF EXISTS (
-      SELECT 1 FROM information_schema.tables
-      WHERE table_catalog = current_database()
-        AND table_schema = _schema_name
-        AND table_name = _table_name
-  )
-  THEN
-    RETURN pg_total_relation_size(format('"%s"."%s"', _schema_name, _table_name));
-  ELSE
-    RETURN 0;
-  END IF;
+  BEGIN
+    SELECT pg_total_relation_size(format('"%s"."%s"', _schema_name, _table_name)) INTO relation_size;
+  EXCEPTION
+    WHEN undefined_table OR OTHERS THEN
+      RAISE NOTICE 'caught undefined_table: "%"."%"', _schema_name, _table_name;
+  END;
+  RETURN relation_size;
 END;
 $$
 LANGUAGE 'plpgsql' VOLATILE;

--- a/scripts-available/CDB_Quota.sql
+++ b/scripts-available/CDB_Quota.sql
@@ -7,7 +7,7 @@ BEGIN
     SELECT pg_total_relation_size(format('"%s"."%s"', _schema_name, _table_name)) INTO relation_size;
   EXCEPTION
     WHEN undefined_table OR OTHERS THEN
-      RAISE NOTICE 'caught undefined_table: "%"."%"', _schema_name, _table_name;
+      RAISE NOTICE 'cartodb._CDB_total_relation_size(''%'', ''%'') caught error: % (%)', _schema_name, _table_name, SQLERRM, SQLSTATE;
   END;
   RETURN relation_size;
 END;


### PR DESCRIPTION
`IF EXISTS` approach was very slow, here it's a faster version using EXCEPTION. It seems to be one order of magnitude faster and very close with raw `pg_total_relation_size` calls.

cc/ @javisantana 

```sql
cartodb_dev_user_359a4d9f-a063-4130-9674-799e90960886_db=# CREATE OR REPLACE FUNCTION cartodb._CDB_total_relation_size(_schema_name TEXT, _table_name TEXT)
cartodb_dev_user_359a4d9f-a063-4130-9674-799e90960886_db-# RETURNS bigint AS
cartodb_dev_user_359a4d9f-a063-4130-9674-799e90960886_db-# $$
cartodb_dev_user_359a4d9f-a063-4130-9674-799e90960886_db$# BEGIN
cartodb_dev_user_359a4d9f-a063-4130-9674-799e90960886_db$#   IF EXISTS (
cartodb_dev_user_359a4d9f-a063-4130-9674-799e90960886_db$#       SELECT 1 FROM information_schema.tables
cartodb_dev_user_359a4d9f-a063-4130-9674-799e90960886_db$#       WHERE table_catalog = current_database()
cartodb_dev_user_359a4d9f-a063-4130-9674-799e90960886_db$#         AND table_schema = _schema_name
cartodb_dev_user_359a4d9f-a063-4130-9674-799e90960886_db$#         AND table_name = _table_name
cartodb_dev_user_359a4d9f-a063-4130-9674-799e90960886_db$#   )
cartodb_dev_user_359a4d9f-a063-4130-9674-799e90960886_db$#   THEN
cartodb_dev_user_359a4d9f-a063-4130-9674-799e90960886_db$#     RETURN pg_total_relation_size(format('"%s"."%s"', _schema_name, _table_name));
cartodb_dev_user_359a4d9f-a063-4130-9674-799e90960886_db$#   ELSE
cartodb_dev_user_359a4d9f-a063-4130-9674-799e90960886_db$#     RETURN 0;
cartodb_dev_user_359a4d9f-a063-4130-9674-799e90960886_db$#   END IF;
cartodb_dev_user_359a4d9f-a063-4130-9674-799e90960886_db$# END;
cartodb_dev_user_359a4d9f-a063-4130-9674-799e90960886_db$# $$
cartodb_dev_user_359a4d9f-a063-4130-9674-799e90960886_db-# LANGUAGE 'plpgsql' VOLATILE;
CREATE FUNCTION
cartodb_dev_user_359a4d9f-a063-4130-9674-799e90960886_db=# EXPLAIN ANALYZE select cartodb._CDB_total_relation_size('public', 'test10');
                                     QUERY PLAN
------------------------------------------------------------------------------------
 Result  (cost=0.00..0.26 rows=1 width=0) (actual time=3.072..3.072 rows=1 loops=1)
 Total runtime: 3.079 ms
(2 rows)

cartodb_dev_user_359a4d9f-a063-4130-9674-799e90960886_db=# EXPLAIN ANALYZE select cartodb._CDB_total_relation_size('public', 'test10');
                                     QUERY PLAN
------------------------------------------------------------------------------------
 Result  (cost=0.00..0.26 rows=1 width=0) (actual time=1.151..1.151 rows=1 loops=1)
 Total runtime: 1.159 ms
(2 rows)

cartodb_dev_user_359a4d9f-a063-4130-9674-799e90960886_db=# EXPLAIN ANALYZE select cartodb._CDB_total_relation_size('public', 'test10');
                                     QUERY PLAN
------------------------------------------------------------------------------------
 Result  (cost=0.00..0.26 rows=1 width=0) (actual time=1.152..1.152 rows=1 loops=1)
 Total runtime: 1.159 ms
(2 rows)

cartodb_dev_user_359a4d9f-a063-4130-9674-799e90960886_db=# EXPLAIN ANALYZE select cartodb._CDB_total_relation_size('public', 'non_existent');
                                     QUERY PLAN
------------------------------------------------------------------------------------
 Result  (cost=0.00..0.26 rows=1 width=0) (actual time=2.112..2.112 rows=1 loops=1)
 Total runtime: 2.134 ms
(2 rows)

cartodb_dev_user_359a4d9f-a063-4130-9674-799e90960886_db=# EXPLAIN ANALYZE select cartodb._CDB_total_relation_size('public', 'non_existent');
                                     QUERY PLAN
------------------------------------------------------------------------------------
 Result  (cost=0.00..0.26 rows=1 width=0) (actual time=1.080..1.080 rows=1 loops=1)
 Total runtime: 1.087 ms
(2 rows)

cartodb_dev_user_359a4d9f-a063-4130-9674-799e90960886_db=# EXPLAIN ANALYZE select cartodb._CDB_total_relation_size('public', 'non_existent');
                                     QUERY PLAN
------------------------------------------------------------------------------------
 Result  (cost=0.00..0.26 rows=1 width=0) (actual time=1.424..1.424 rows=1 loops=1)
 Total runtime: 1.434 ms
(2 rows)

cartodb_dev_user_359a4d9f-a063-4130-9674-799e90960886_db=# CREATE OR REPLACE FUNCTION cartodb._CDB_total_relation_size(_schema_name TEXT, _table_name TEXT)
cartodb_dev_user_359a4d9f-a063-4130-9674-799e90960886_db-# RETURNS bigint AS
cartodb_dev_user_359a4d9f-a063-4130-9674-799e90960886_db-# $$
cartodb_dev_user_359a4d9f-a063-4130-9674-799e90960886_db$# DECLARE relation_size bigint := 0;
cartodb_dev_user_359a4d9f-a063-4130-9674-799e90960886_db$# BEGIN
cartodb_dev_user_359a4d9f-a063-4130-9674-799e90960886_db$#   BEGIN
cartodb_dev_user_359a4d9f-a063-4130-9674-799e90960886_db$#     SELECT pg_total_relation_size(format('"%s"."%s"', _schema_name, _table_name)) INTO relation_size;
cartodb_dev_user_359a4d9f-a063-4130-9674-799e90960886_db$#   EXCEPTION
cartodb_dev_user_359a4d9f-a063-4130-9674-799e90960886_db$#     WHEN undefined_table OR OTHERS THEN
cartodb_dev_user_359a4d9f-a063-4130-9674-799e90960886_db$#       RAISE NOTICE 'cartodb._CDB_total_relation_size(''%'', ''%'') caught error: % (%)', _schema_name, _table_name, SQLERRM, SQLSTATE;
cartodb_dev_user_359a4d9f-a063-4130-9674-799e90960886_db$#   END;
cartodb_dev_user_359a4d9f-a063-4130-9674-799e90960886_db$#   RETURN relation_size;
cartodb_dev_user_359a4d9f-a063-4130-9674-799e90960886_db$# END;
cartodb_dev_user_359a4d9f-a063-4130-9674-799e90960886_db$# $$
cartodb_dev_user_359a4d9f-a063-4130-9674-799e90960886_db-# LANGUAGE 'plpgsql' VOLATILE;
CREATE FUNCTION
cartodb_dev_user_359a4d9f-a063-4130-9674-799e90960886_db=# EXPLAIN ANALYZE select cartodb._CDB_total_relation_size('public', 'test10');
                                     QUERY PLAN
------------------------------------------------------------------------------------
 Result  (cost=0.00..0.26 rows=1 width=0) (actual time=0.349..0.350 rows=1 loops=1)
 Total runtime: 0.356 ms
(2 rows)

cartodb_dev_user_359a4d9f-a063-4130-9674-799e90960886_db=# EXPLAIN ANALYZE select cartodb._CDB_total_relation_size('public', 'test10');
                                     QUERY PLAN
------------------------------------------------------------------------------------
 Result  (cost=0.00..0.26 rows=1 width=0) (actual time=0.203..0.203 rows=1 loops=1)
 Total runtime: 0.211 ms
(2 rows)

cartodb_dev_user_359a4d9f-a063-4130-9674-799e90960886_db=# EXPLAIN ANALYZE select cartodb._CDB_total_relation_size('public', 'test10');
                                     QUERY PLAN
------------------------------------------------------------------------------------
 Result  (cost=0.00..0.26 rows=1 width=0) (actual time=0.255..0.255 rows=1 loops=1)
 Total runtime: 0.263 ms
(2 rows)

cartodb_dev_user_359a4d9f-a063-4130-9674-799e90960886_db=# EXPLAIN ANALYZE select cartodb._CDB_total_relation_size('public', 'non_existent');
NOTICE:  cartodb._CDB_total_relation_size('public', 'non_existent') caught error: relation "public.non_existent" does not exist (42P01)
                                     QUERY PLAN
------------------------------------------------------------------------------------
 Result  (cost=0.00..0.26 rows=1 width=0) (actual time=0.164..0.164 rows=1 loops=1)
 Total runtime: 0.171 ms
(2 rows)

cartodb_dev_user_359a4d9f-a063-4130-9674-799e90960886_db=# EXPLAIN ANALYZE select cartodb._CDB_total_relation_size('public', 'non_existent');
NOTICE:  cartodb._CDB_total_relation_size('public', 'non_existent') caught error: relation "public.non_existent" does not exist (42P01)
                                     QUERY PLAN
------------------------------------------------------------------------------------
 Result  (cost=0.00..0.26 rows=1 width=0) (actual time=0.085..0.085 rows=1 loops=1)
 Total runtime: 0.093 ms
(2 rows)

cartodb_dev_user_359a4d9f-a063-4130-9674-799e90960886_db=# EXPLAIN ANALYZE select cartodb._CDB_total_relation_size('public', 'non_existent');
NOTICE:  cartodb._CDB_total_relation_size('public', 'non_existent') caught error: relation "public.non_existent" does not exist (42P01)
                                     QUERY PLAN
------------------------------------------------------------------------------------
 Result  (cost=0.00..0.26 rows=1 width=0) (actual time=0.076..0.076 rows=1 loops=1)
 Total runtime: 0.083 ms
(2 rows)

cartodb_dev_user_359a4d9f-a063-4130-9674-799e90960886_db=# EXPLAIN ANALYZE select pg_total_relation_size('public.test10');
                                     QUERY PLAN
------------------------------------------------------------------------------------
 Result  (cost=0.00..0.01 rows=1 width=0) (actual time=0.206..0.206 rows=1 loops=1)
 Total runtime: 0.221 ms
(2 rows)

cartodb_dev_user_359a4d9f-a063-4130-9674-799e90960886_db=# EXPLAIN ANALYZE select pg_total_relation_size('public.test10');
                                     QUERY PLAN
------------------------------------------------------------------------------------
 Result  (cost=0.00..0.01 rows=1 width=0) (actual time=0.130..0.130 rows=1 loops=1)
 Total runtime: 0.141 ms
(2 rows)

cartodb_dev_user_359a4d9f-a063-4130-9674-799e90960886_db=# EXPLAIN ANALYZE select pg_total_relation_size('public.test10');
                                     QUERY PLAN
------------------------------------------------------------------------------------
 Result  (cost=0.00..0.01 rows=1 width=0) (actual time=0.132..0.132 rows=1 loops=1)
 Total runtime: 0.143 ms
(2 rows)
```