### PR TITLE
Fix for index generation when renaming table #123

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+0.9.4 (2015-08-28)
+------------------
+* Fixed issue with indices when renaming tables [#123](https://github.com/CartoDB/cartodb-postgresql/issues/123)
+
 0.9.3 (2015-08-27)
 ------------------
 * Modify sampling of quota trigger [#126](https://github.com/CartoDB/cartodb-postgresql/issues/126)

--- a/scripts-available/CDB_CartodbfyTable.sql
+++ b/scripts-available/CDB_CartodbfyTable.sql
@@ -1234,7 +1234,7 @@ BEGIN
     AND c.oid = reloid
     AND am.amname != 'gist'
   LOOP
-    sql := Format('CREATE INDEX %s_%s_gix ON %s USING GIST (%s)', relname, rec.attname, reloid::text, rec.attname);
+    sql := Format('CREATE INDEX ON %s USING GIST (%s)', reloid::text, rec.attname);
     PERFORM _CDB_SQL(sql, '_CDB_Add_Indexes');
   END LOOP;
     

--- a/test/CDB_CartodbfyTableTest.sql
+++ b/test/CDB_CartodbfyTableTest.sql
@@ -216,6 +216,15 @@ WHERE c.conrelid = 't'::regclass and a.attrelid = c.conrelid
 AND c.conkey[1] = a.attnum AND NOT a.attisdropped;
 DROP TABLE t;
 
+-- tables can be renamed and there's no index name clashing #123
+CREATE TABLE original();
+SELECT CDB_CartodbfyTable('original');
+ALTER TABLE original RENAME TO original_renamed;
+CREATE TABLE original();
+SELECT CDB_CartodbfyTable('original');
+DROP TABLE original_renamed;
+DROP TABLE original;
+
 -- TODO: table with existing custom-triggered the_geom
 
 DROP FUNCTION CDB_CartodbfyTableCheck(regclass, text);

--- a/test/CDB_CartodbfyTableTest_expect
+++ b/test/CDB_CartodbfyTableTest_expect
@@ -51,5 +51,12 @@ CREATE TABLE
 cartodb_id serial primary key cartodbfied fine
 t_pkey|cartodb_id
 DROP TABLE
+CREATE TABLE
+original
+ALTER TABLE
+CREATE TABLE
+original
+DROP TABLE
+DROP TABLE
 DROP FUNCTION
 DROP FUNCTION


### PR DESCRIPTION
Just let the DB decide the name of the index, as it was done in the previous version.

@rochoa or @pramsey please kindly review.