### PR TITLE
Do not remove old function #120

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+next (2015-??-??)
+-----------------
+* Removed `DROP FUNCTION IF EXISTS cdb_usertables(text);` [#129](https://github.com/CartoDB/cartodb-postgresql/pull/129). This was needed for upgrading between 0.7.4 to 0.8.0 but is no longer needed.
+
 0.9.4 (2015-08-28)
 ------------------
 * Fixed issue with indices when renaming tables [#123](https://github.com/CartoDB/cartodb-postgresql/issues/123)

--- a/scripts-available/CDB_UserTables.sql
+++ b/scripts-available/CDB_UserTables.sql
@@ -5,7 +5,6 @@
 --
 -- Currently accepted permissions are: 'public', 'private' or 'all'
 --
-DROP FUNCTION IF EXISTS cdb_usertables(text);
 CREATE OR REPLACE FUNCTION CDB_UserTables(perm text DEFAULT 'all')
 RETURNS SETOF name
 AS $$


### PR DESCRIPTION
The `DROP FUNCTION IF EXISTS` was added as transient code and not needed
anymore. See the ticket #120 for more information on this.

@rochoa mini-review

@juanignaciosl I'd like this small fix to go in next version if possible.