### PR TITLE
Column regclass

### DIFF
--- a/scripts-available/CDB_ColumnNames.sql
+++ b/scripts-available/CDB_ColumnNames.sql
@@ -7,7 +7,7 @@ AS $$
       FROM information_schema.columns c, pg_class _tn, pg_namespace _sn
       WHERE table_name = _tn.relname
         AND table_schema = _sn.nspname
-        AND _tn.oid = $1::regclass::oid
+        AND _tn.oid = $1::oid
         AND _sn.oid = _tn.relnamespace;
          
 $$ LANGUAGE SQL;

--- a/scripts-available/CDB_ColumnNames.sql
+++ b/scripts-available/CDB_ColumnNames.sql
@@ -3,11 +3,12 @@ CREATE OR REPLACE FUNCTION CDB_ColumnNames(REGCLASS)
 RETURNS SETOF information_schema.sql_identifier
 AS $$
 
-    SELECT column_name 
-      FROM information_schema.columns 
-      WHERE
-        table_name IN (SELECT CDB_UserTables())
-        AND table_name = '' || $1 || '';
+    SELECT c.column_name
+      FROM information_schema.columns c, pg_class _tn, pg_namespace _sn
+      WHERE table_name = _tn.relname
+        AND table_schema = _sn.nspname
+        AND _tn.oid = $1::regclass::oid
+        AND _sn.oid = _tn.relnamespace;
          
 $$ LANGUAGE SQL;
 

--- a/scripts-available/CDB_ColumnType.sql
+++ b/scripts-available/CDB_ColumnType.sql
@@ -8,7 +8,7 @@ AS $$
       WHERE table_name = _tn.relname
         AND table_schema = _sn.nspname
         AND column_name = $2
-        AND _tn.oid = $1::regclass::oid
+        AND _tn.oid = $1::oid
         AND _sn.oid = _tn.relnamespace;
          
 $$ LANGUAGE SQL;

--- a/scripts-available/CDB_ColumnType.sql
+++ b/scripts-available/CDB_ColumnType.sql
@@ -3,12 +3,13 @@ CREATE OR REPLACE FUNCTION CDB_ColumnType(REGCLASS, TEXT)
 RETURNS information_schema.character_data
 AS $$
 
-    SELECT data_type 
-      FROM information_schema.columns 
-      WHERE
-        table_name IN (SELECT CDB_UserTables())
-        AND table_name = '' || $1 || ''
-        AND column_name = '' || quote_ident($2) || '';
+    SELECT c.data_type
+      FROM information_schema.columns c, pg_class _tn, pg_namespace _sn
+      WHERE table_name = _tn.relname
+        AND table_schema = _sn.nspname
+        AND column_name = $2
+        AND _tn.oid = $1::regclass::oid
+        AND _sn.oid = _tn.relnamespace;
          
 $$ LANGUAGE SQL;
 

--- a/test/extension/run_at_cartodb_schema.sql
+++ b/test/extension/run_at_cartodb_schema.sql
@@ -1,4 +1,6 @@
 SET SCHEMA 'cartodb';
 \i scripts-available/CDB_Quota.sql
 \i scripts-available/CDB_TableMetadata.sql
+\i scripts-available/CDB_ColumnNames.sql
+\i scripts-available/CDB_ColumnType.sql
 SET SCHEMA 'public';

--- a/test/extension/test.sh
+++ b/test/extension/test.sh
@@ -350,6 +350,9 @@ function test_cdb_column_names() {
     # Using schema from owner
     sql cdb_testmember_1 "SELECT string_agg(c,'') from (SELECT cartodb.CDB_ColumnNames('cdb_testmember_1.table_cnames') c) as s" should "carto"
 
+    ## it's not possible to get column names from a table where you don't have permissions
+    sql cdb_testmember_2 "SELECT string_agg(c,'') from (SELECT cartodb.CDB_ColumnNames('cdb_testmember_1.table_cnames') c) as s" fails
+
     sql cdb_testmember_1 'DROP TABLE cdb_testmember_1.table_cnames'
     sql cdb_testmember_2 'DROP TABLE cdb_testmember_2.table_cnames'
 }

--- a/test/extension/test.sh
+++ b/test/extension/test.sh
@@ -347,6 +347,9 @@ function test_cdb_column_names() {
     sql postgres "SELECT string_agg(c,'') from (SELECT cartodb.CDB_ColumnNames('cdb_testmember_1.table_cnames'::regclass) c) as s" should "carto"
     sql postgres "SELECT string_agg(c,'') from (SELECT cartodb.CDB_ColumnNames('cdb_testmember_2.table_cnames') c) as s" should "db"
 
+    # Using schema from owner
+    sql cdb_testmember_1 "SELECT string_agg(c,'') from (SELECT cartodb.CDB_ColumnNames('cdb_testmember_1.table_cnames') c) as s" should "carto"
+
     sql cdb_testmember_1 'DROP TABLE cdb_testmember_1.table_cnames'
     sql cdb_testmember_2 'DROP TABLE cdb_testmember_2.table_cnames'
 }

--- a/test/extension/test.sh
+++ b/test/extension/test.sh
@@ -351,6 +351,20 @@ function test_cdb_column_names() {
     sql cdb_testmember_2 'DROP TABLE cdb_testmember_2.table_cnames'
 }
 
+function test_cdb_column_type() {
+    sql cdb_testmember_1 'CREATE TABLE cdb_testmember_1.table_ctype(c int, a int, r int, t int, o int);'
+    sql cdb_testmember_2 'CREATE TABLE cdb_testmember_2.table_ctype(c text, a text, r text, t text, o text);'
+
+    sql cdb_testmember_1 "SELECT cartodb.CDB_ColumnType('table_ctype', 'c')" should "integer"
+    sql cdb_testmember_2 "SELECT cartodb.CDB_ColumnType('table_ctype', 'c')" should "text"
+
+    sql postgres "SELECT cartodb.CDB_ColumnType('cdb_testmember_1.table_ctype', 'c')" should "integer"
+    sql postgres "SELECT cartodb.CDB_ColumnType('cdb_testmember_2.table_ctype', 'c')" should "text"
+
+    sql cdb_testmember_1 'DROP TABLE cdb_testmember_1.table_ctype'
+    sql cdb_testmember_2 'DROP TABLE cdb_testmember_2.table_ctype'
+}
+
 #################################################### TESTS END HERE ####################################################
 
 run_tests $@

--- a/test/extension/test.sh
+++ b/test/extension/test.sh
@@ -337,6 +337,20 @@ function test_cdb_tablemetadatatouch_fails_from_user_without_permission() {
     sql postgres "REVOKE ALL ON CDB_TableMetadata FROM cdb_testmember_1;"
 }
 
+function test_cdb_column_names() {
+    sql cdb_testmember_1 'CREATE TABLE cdb_testmember_1.table_cnames(c int, a int, r int, t int, o int);'
+    sql cdb_testmember_2 'CREATE TABLE cdb_testmember_2.table_cnames(d int, b int);'
+
+    sql cdb_testmember_1 "SELECT string_agg(c,'') from (SELECT cartodb.CDB_ColumnNames('table_cnames') c) as s" should "carto"
+    sql cdb_testmember_2 "SELECT string_agg(c,'') from (SELECT cartodb.CDB_ColumnNames('table_cnames') c) as s" should "db"
+
+    sql postgres "SELECT string_agg(c,'') from (SELECT cartodb.CDB_ColumnNames('cdb_testmember_1.table_cnames'::regclass) c) as s" should "carto"
+    sql postgres "SELECT string_agg(c,'') from (SELECT cartodb.CDB_ColumnNames('cdb_testmember_2.table_cnames') c) as s" should "db"
+
+    sql cdb_testmember_1 'DROP TABLE cdb_testmember_1.table_cnames'
+    sql cdb_testmember_2 'DROP TABLE cdb_testmember_2.table_cnames'
+}
+
 #################################################### TESTS END HERE ####################################################
 
 run_tests $@


### PR DESCRIPTION
Uses schema and table name from regclass to avoid query tables with same name in different schemas.

Fixes #122 and fixes #130.