### PR TITLE
Readd update_updated_at function (still used by old tables)

### DIFF
--- a/scripts-available/CDB_CartodbfyTable.sql
+++ b/scripts-available/CDB_CartodbfyTable.sql
@@ -280,6 +280,16 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql VOLATILE;
 
+--- Trigger to update the updated_at column. No longer added by default
+--- but kept here for compatibility with old tables which still have this behavior
+--- and have it added
+CREATE OR REPLACE FUNCTION _CDB_update_updated_at()
+  RETURNS TRIGGER AS $$
+BEGIN
+   NEW.updated_at := now();
+   RETURN NEW;
+END;
+$$ LANGUAGE plpgsql VOLATILE;
 
 -- Auxiliary function
 CREATE OR REPLACE FUNCTION cartodb._CDB_is_raster_table(schema_name TEXT, reloid REGCLASS)


### PR DESCRIPTION
The _CDB_update_updated_at() function was no longer added to tables since #107, but it is attached with a trigger to old tables, causing a pg_dump and further pg_restore of a database of this kind to fail as the current version (0.10.0) does not have this function.
