### PR TITLE
Fix creation of type _cdb_has_usable_geom_record

### DIFF
--- a/scripts-available/CDB_CartodbfyTable.sql
+++ b/scripts-available/CDB_CartodbfyTable.sql
@@ -688,16 +688,20 @@ BEGIN
 END;
 $$ LANGUAGE 'plpgsql';
 
-
-CREATE TYPE _cdb_has_usable_geom_record
-  AS (has_usable_geoms boolean,
-      text_geom_column boolean,
-      text_geom_column_name text,
-      text_geom_column_srid boolean,
-      has_geom boolean,
-      has_geom_name text,
-      has_mercgeom boolean,
-      has_mercgeom_name text);
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = '_cdb_has_usable_geom_record') THEN
+    CREATE TYPE _cdb_has_usable_geom_record
+      AS (has_usable_geoms boolean,
+        text_geom_column boolean,
+        text_geom_column_name text,
+        text_geom_column_srid boolean,
+        has_geom boolean,
+        has_geom_name text,
+        has_mercgeom boolean,
+        has_mercgeom_name text);
+    END IF;
+END$$;
 
 DROP FUNCTION IF EXISTS _CDB_Has_Usable_Geom(REGCLASS);
 CREATE OR REPLACE FUNCTION _CDB_Has_Usable_Geom(reloid REGCLASS)


### PR DESCRIPTION
Fix the ERROR:  type "_cdb_has_usable_geom_record" already exists by
checking for existence before. Duly noted for upgrades.

@juanignaciosl please review

Just FYI, some more pain on upgrades @rochoa and @pramsey 