### PR TITLE
Add DROP FUNCTION back to allow migrations #160

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # cartodb/Makefile
 
 EXTENSION = cartodb
-EXTVERSION = 0.10.1
+EXTVERSION = 0.10.2
 
 SED = sed
 
@@ -49,6 +49,7 @@ UPGRADABLE = \
   0.9.4 \
   0.10.0 \
   0.10.1 \
+  0.10.2 \
   $(EXTVERSION)dev \
   $(EXTVERSION)next \
   $(END)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,10 @@
 next (2015-mm-dd)
 -----------------
 
+0.10.2 (2015-09-24)
+-------------------
+* Add back the `DROP FUNCTION IF EXISTS CDB_UserTables(text);` to be able to upgrade from `0.7.3` upward [#160](https://github.com/CartoDB/cartodb-postgresql/issues/160)
+
 0.10.1 (2015-09-16)
 -------------------
 * Get back the `update_updated_at` function (still used by old tables) [#143](https://github.com/CartoDB/cartodb-postgresql/pull/143)

--- a/scripts-available/CDB_UserTables.sql
+++ b/scripts-available/CDB_UserTables.sql
@@ -5,6 +5,7 @@
 --
 -- Currently accepted permissions are: 'public', 'private' or 'all'
 --
+DROP FUNCTION IF EXISTS CDB_UserTables(text);
 CREATE OR REPLACE FUNCTION CDB_UserTables(perm text DEFAULT 'all')
 RETURNS SETOF name
 AS $$


### PR DESCRIPTION
@rochoa please review

Just FYI: what changed between 0.7.4 and 0.8.0 was the return type of that function.

I'll test the upgrades by checking out that specific revision, installing and then going up to 0.10.2. I'll merge as soon as tests get passed (both clinker and those manual tests).

cc/ @azamorano 