### PR TITLE
162 allow non sync group permission management queries

### DIFF
--- a/scripts-available/CDB_Groups.sql
+++ b/scripts-available/CDB_Groups.sql
@@ -105,10 +105,22 @@ FUNCTION cartodb.CDB_Group_Table_GrantRead(group_name text, username text, table
 DECLARE
     group_role TEXT;
 BEGIN
+    PERFORM cartodb.CDB_Group_Table_GrantRead(group_name, username, table_name, true);
+END
+$$ LANGUAGE PLPGSQL VOLATILE;
+
+CREATE OR REPLACE
+FUNCTION cartodb.CDB_Group_Table_GrantRead(group_name text, username text, table_name text, sync boolean)
+    RETURNS VOID AS $$
+DECLARE
+    group_role TEXT;
+BEGIN
     group_role := cartodb._CDB_Group_GroupRole(group_name);
     EXECUTE format('GRANT USAGE ON SCHEMA %I TO %I', username, group_role);
     EXECUTE format('GRANT SELECT ON TABLE %I.%I TO %I', username, table_name, group_role );
-    PERFORM cartodb._CDB_Group_Table_GrantPermission_API(group_name, username, table_name, 'r');
+    IF(sync) THEN
+      PERFORM cartodb._CDB_Group_Table_GrantPermission_API(group_name, username, table_name, 'r');
+    END IF;
 END
 $$ LANGUAGE PLPGSQL VOLATILE;
 
@@ -119,11 +131,23 @@ FUNCTION cartodb.CDB_Group_Table_GrantReadWrite(group_name text, username text, 
 DECLARE
     group_role TEXT;
 BEGIN
+    PERFORM cartodb.CDB_Group_Table_GrantReadWrite(group_name, username, table_name, true);
+END
+$$ LANGUAGE PLPGSQL VOLATILE;
+
+CREATE OR REPLACE
+FUNCTION cartodb.CDB_Group_Table_GrantReadWrite(group_name text, username text, table_name text, sync boolean)
+    RETURNS VOID AS $$
+DECLARE
+    group_role TEXT;
+BEGIN
     group_role := cartodb._CDB_Group_GroupRole(group_name);
     EXECUTE format('GRANT USAGE ON SCHEMA %I TO %I', username, group_role);
     EXECUTE format('GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE %I.%I TO %I', username, table_name, group_role);
     PERFORM cartodb._CDB_Group_TableSequences_Permission(group_name, username, table_name, true);
-    PERFORM cartodb._CDB_Group_Table_GrantPermission_API(group_name, username, table_name, 'w');
+    IF(sync) THEN
+      PERFORM cartodb._CDB_Group_Table_GrantPermission_API(group_name, username, table_name, 'w');
+    END IF;
 END
 $$ LANGUAGE PLPGSQL VOLATILE;
 
@@ -160,10 +184,22 @@ FUNCTION cartodb.CDB_Group_Table_RevokeAll(group_name text, username text, table
 DECLARE
     group_role TEXT;
 BEGIN
+    PERFORM cartodb.CDB_Group_Table_RevokeAll(group_name, username, table_name, true);
+END
+$$ LANGUAGE PLPGSQL VOLATILE;
+
+CREATE OR REPLACE
+FUNCTION cartodb.CDB_Group_Table_RevokeAll(group_name text, username text, table_name text, sync boolean)
+    RETURNS VOID AS $$
+DECLARE
+    group_role TEXT;
+BEGIN
     group_role := cartodb._CDB_Group_GroupRole(group_name);
     EXECUTE format('REVOKE ALL ON TABLE %I.%I FROM %I', username, table_name, group_role);
     PERFORM cartodb._CDB_Group_TableSequences_Permission(group_name, username, table_name, false);
-    PERFORM cartodb._CDB_Group_Table_RevokeAllPermission_API(group_name, username, table_name);
+    IF(sync) THEN
+      PERFORM cartodb._CDB_Group_Table_RevokeAllPermission_API(group_name, username, table_name);
+    END IF;
 END
 $$ LANGUAGE PLPGSQL VOLATILE;
 

--- a/scripts-available/CDB_Groups.sql
+++ b/scripts-available/CDB_Groups.sql
@@ -105,12 +105,12 @@ FUNCTION cartodb.CDB_Group_Table_GrantRead(group_name text, username text, table
 DECLARE
     group_role TEXT;
 BEGIN
-    PERFORM cartodb.CDB_Group_Table_GrantRead(group_name, username, table_name, true);
+    PERFORM cartodb._CDB_Group_Table_GrantRead(group_name, username, table_name, true);
 END
 $$ LANGUAGE PLPGSQL VOLATILE;
 
 CREATE OR REPLACE
-FUNCTION cartodb.CDB_Group_Table_GrantRead(group_name text, username text, table_name text, sync boolean)
+FUNCTION cartodb._CDB_Group_Table_GrantRead(group_name text, username text, table_name text, sync boolean)
     RETURNS VOID AS $$
 DECLARE
     group_role TEXT;
@@ -131,12 +131,12 @@ FUNCTION cartodb.CDB_Group_Table_GrantReadWrite(group_name text, username text, 
 DECLARE
     group_role TEXT;
 BEGIN
-    PERFORM cartodb.CDB_Group_Table_GrantReadWrite(group_name, username, table_name, true);
+    PERFORM cartodb._CDB_Group_Table_GrantReadWrite(group_name, username, table_name, true);
 END
 $$ LANGUAGE PLPGSQL VOLATILE;
 
 CREATE OR REPLACE
-FUNCTION cartodb.CDB_Group_Table_GrantReadWrite(group_name text, username text, table_name text, sync boolean)
+FUNCTION cartodb._CDB_Group_Table_GrantReadWrite(group_name text, username text, table_name text, sync boolean)
     RETURNS VOID AS $$
 DECLARE
     group_role TEXT;
@@ -184,12 +184,12 @@ FUNCTION cartodb.CDB_Group_Table_RevokeAll(group_name text, username text, table
 DECLARE
     group_role TEXT;
 BEGIN
-    PERFORM cartodb.CDB_Group_Table_RevokeAll(group_name, username, table_name, true);
+    PERFORM cartodb._CDB_Group_Table_RevokeAll(group_name, username, table_name, true);
 END
 $$ LANGUAGE PLPGSQL VOLATILE;
 
 CREATE OR REPLACE
-FUNCTION cartodb.CDB_Group_Table_RevokeAll(group_name text, username text, table_name text, sync boolean)
+FUNCTION cartodb._CDB_Group_Table_RevokeAll(group_name text, username text, table_name text, sync boolean)
     RETURNS VOID AS $$
 DECLARE
     group_role TEXT;

--- a/scripts-available/CDB_Groups_API.sql
+++ b/scripts-available/CDB_Groups_API.sql
@@ -157,6 +157,7 @@ $$
 $$ LANGUAGE 'plpythonu' VOLATILE;
 
 -- url must contain a '%s' placeholder that will be replaced by current_database, for security reasons.
+-- headers = { 'Authorization': params['auth'], 'Content-Type': 'application/json', 'X-Forwarded-Proto': 'https' }
 CREATE OR REPLACE
 FUNCTION cartodb._CDB_Group_API_Request(method text, url text, body text, valid_return_codes int[])
     RETURNS int AS
@@ -167,7 +168,7 @@ $$
     if params['host'] is None:
       return None
 
-    headers = { 'Authorization': params['auth'], 'Content-Type': 'application/json', 'X-Forwarded-Proto': 'https' }
+    headers = { 'Authorization': params['auth'], 'Content-Type': 'application/json' }
 
     retry = 3
 

--- a/scripts-available/CDB_Groups_API.sql
+++ b/scripts-available/CDB_Groups_API.sql
@@ -157,7 +157,6 @@ $$
 $$ LANGUAGE 'plpythonu' VOLATILE;
 
 -- url must contain a '%s' placeholder that will be replaced by current_database, for security reasons.
--- headers = { 'Authorization': params['auth'], 'Content-Type': 'application/json', 'X-Forwarded-Proto': 'https' }
 CREATE OR REPLACE
 FUNCTION cartodb._CDB_Group_API_Request(method text, url text, body text, valid_return_codes int[])
     RETURNS int AS
@@ -168,7 +167,7 @@ $$
     if params['host'] is None:
       return None
 
-    headers = { 'Authorization': params['auth'], 'Content-Type': 'application/json' }
+    headers = { 'Authorization': params['auth'], 'Content-Type': 'application/json', 'X-Forwarded-Proto': 'https' }
 
     retry = 3
 


### PR DESCRIPTION
This closes #162. @rafatower, CR this, please. I needed non-sync flags for permissions to fix CartoDB/cartodb#5768 (more information at CartoDB/cartodb#5763). I kept existing nomenclature for sync ones, adding private versions to be used only from the editor.