### PR TITLE
move alaska, hawaii, and puerto rico into frame with lower 48 states all in an albers

### DIFF
--- a/scripts-available/CDB_Albers.sql
+++ b/scripts-available/CDB_Albers.sql
@@ -9,30 +9,23 @@
 --  output: geometries of states in albers projections of the states
 -- 
 -- Projections:
--- 		- 
+--		- Lower 48 states: http://spatialreference.org/ref/sr-org/7965/
+-- 		- Alaska: http://spatialreference.org/ref/epsg/3338/
 --		- Puerto Rico: http://www.spatialreference.org/ref/epsg/nad83-puerto-rico-virgin-is/
 --		- Hawaii: http://epsg.io/102007
 
 
-CREATE OR REPLACE FUNCTION CDB_AlbersUSA (g geometry, state text, srid numeric DEFAULT 3857) RETURNS geometry as $$ 
+CREATE OR REPLACE FUNCTION CDB_Albers50 (g geometry, state text) RETURNS geometry as $$
 DECLARE
 	reply geometry;
-	new_srid INT;
-	alaska text[];
-	hawaii text[];
-	puertorico text[];
+	srid INT;
+	alaska text[] = '{"Alaska","AK","02"}'::text[];
+	hawaii text[] = '{"Hawaii","HI","15"}'::text[];
+	puertorico text[] = '{"Puerto Rico","PR","72"}'::text[];
 BEGIN
 	
-	alaska = '{"Alaska","AK","02"}'::text[];
-	hawaii = '{"Hawaii","HI","15"}'::text[];
-	puertorico = '{"Puerto Rico","PR","72"}'::text[];
-	
-	-- decide on SRID to use
-	IF srid = 3857 THEN 
-		new_srid = ST_SRID(g);
-	ELSE
-		new_srid = srid;
-	END IF;
+	-- convert to wgs84
+	IF ST_SRID(g) != 4326 THEN g = ST_Transform(g,4326); END IF;
 
 	EXECUTE 'SELECT
 	    ST_SetSRID(
@@ -82,10 +75,10 @@ BEGIN
 				ELSE
 					ST_Transform($1,42303)
   				END
-  				, $6
+  				, 3857
   			)'
 	INTO reply
-	USING g, state, alaska, hawaii, puertorico, new_srid;
+	USING g, state, alaska, hawaii, puertorico;
 
 	RETURN reply;
 

--- a/scripts-available/CDB_Albers.sql
+++ b/scripts-available/CDB_Albers.sql
@@ -8,13 +8,13 @@
 --  output: geometries of states in albers projections of the states
 -- 
 -- Projections:
---		- Lower 48 states: http://spatialreference.org/ref/sr-org/7965/
+--		- Lower 48 states: http://epsg.io/42303
 -- 		- Alaska: http://spatialreference.org/ref/epsg/3338/
 --		- Puerto Rico: http://www.spatialreference.org/ref/epsg/nad83-puerto-rico-virgin-is/
 --		- Hawaii: http://epsg.io/102007
 
 
-CREATE OR REPLACE FUNCTION CDB_Albers50 (g geometry, state text) RETURNS geometry as $$
+CREATE OR REPLACE FUNCTION CDB_AlbersUSA (g geometry, state text) RETURNS geometry as $$
 DECLARE
 	reply geometry;
 	srid INT;
@@ -30,10 +30,11 @@ BEGIN
 	    ST_SetSRID(
 	    	CASE 
   				WHEN $2 = any($3)
+  					THEN
 					ST_Scale(
 						ST_Translate(
 							ST_Transform(
-								the_geom
+								$1
 								, 3338
 							)
 							, -3800000
@@ -73,10 +74,12 @@ BEGIN
 				ELSE
 					ST_Transform($1,42303)
   				END
-  				, 4326
+  				, 3857
   			)'
 	INTO reply
 	USING g, state, alaska, hawaii, puertorico;
+
+	reply = ST_Transform(reply,4326);
 
 	RETURN reply;
 

--- a/scripts-available/CDB_Albers.sql
+++ b/scripts-available/CDB_Albers.sql
@@ -1,10 +1,9 @@
 
 --  Convert your states (or other geometries id'd by state) to 
---    display as an albers projection
---  Andy Eschbacher, 09/2015
+--    display as with Alaska, Hawaii, and Puerto Rico transcaled
 --
 --  @param g: input geometry
---  @param state: column identifying the state (name, abbreviation, FP)
+--  @param state: column identifying the state (name, postal abbreviation, state FP)
 --  
 --  output: geometries of states in albers projections of the states
 -- 
@@ -31,18 +30,17 @@ BEGIN
 	    ST_SetSRID(
 	    	CASE 
   				WHEN $2 = any($3)
-    				THEN
 					ST_Scale(
 						ST_Translate(
 							ST_Transform(
-								$1
+								the_geom
 								, 3338
 							)
 							, -3800000
 							, -900000
 						)
-						, 0.55
-						, 0.55
+						, 0.7
+						, 0.7
 					)
 				WHEN $2 = any($4)
 					THEN 
@@ -65,7 +63,7 @@ BEGIN
   							ST_Translate(
   								$1
 			                    , 10
-			                    , -4
+			                    , -1.5
 			                )
 			                , 32161
 						)
@@ -75,7 +73,7 @@ BEGIN
 				ELSE
 					ST_Transform($1,42303)
   				END
-  				, 3857
+  				, 4326
   			)'
 	INTO reply
 	USING g, state, alaska, hawaii, puertorico;

--- a/scripts-available/CDB_Albers.sql
+++ b/scripts-available/CDB_Albers.sql
@@ -1,0 +1,93 @@
+
+--  Convert your states (or other geometries id'd by state) to 
+--    display as an albers projection
+--  Andy Eschbacher, 09/2015
+--
+--  @param g: input geometry
+--  @param state: column identifying the state (name, abbreviation, FP)
+--  
+--  output: geometries of states in albers projections of the states
+-- 
+-- Projections:
+-- 		- 
+--		- Puerto Rico: http://www.spatialreference.org/ref/epsg/nad83-puerto-rico-virgin-is/
+--		- Hawaii: http://epsg.io/102007
+
+
+CREATE OR REPLACE FUNCTION CDB_AlbersUSA (g geometry, state text, srid numeric DEFAULT 3857) RETURNS geometry as $$ 
+DECLARE
+	reply geometry;
+	new_srid INT;
+	alaska text[];
+	hawaii text[];
+	puertorico text[];
+BEGIN
+	
+	alaska = '{"Alaska","AK","02"}'::text[];
+	hawaii = '{"Hawaii","HI","15"}'::text[];
+	puertorico = '{"Puerto Rico","PR","72"}'::text[];
+	
+	-- decide on SRID to use
+	IF srid = 3857 THEN 
+		new_srid = ST_SRID(g);
+	ELSE
+		new_srid = srid;
+	END IF;
+
+	EXECUTE 'SELECT
+	    ST_SetSRID(
+	    	CASE 
+  				WHEN $2 = any($3)
+    				THEN
+					ST_Scale(
+						ST_Translate(
+							ST_Transform(
+								$1
+								, 3338
+							)
+							, -3800000
+							, -900000
+						)
+						, 0.55
+						, 0.55
+					)
+				WHEN $2 = any($4)
+					THEN 
+  					ST_Scale(
+  						ST_Transform(
+  							ST_Translate(
+  								$1
+			                    , -8
+			                    , -5
+			                )
+			                , 102007
+			            )
+			            , 1.2
+			            , 1.2
+			        )
+				WHEN $2 = any($5)
+					THEN 
+  					ST_Scale(
+  						ST_Transform(
+  							ST_Translate(
+  								$1
+			                    , 10
+			                    , -4
+			                )
+			                , 32161
+						)
+						, 1.5
+						, 1.5
+					)
+				ELSE
+					ST_Transform($1,42303)
+  				END
+  				, $6
+  			)'
+	INTO reply
+	USING g, state, alaska, hawaii, puertorico, new_srid;
+
+	RETURN reply;
+
+END; 
+$$ language plpgsql IMMUTABLE;


### PR DESCRIPTION
This function projects U.S. states and Puerto Rico into a frame that's easy to view for election maps, etc.

Sample usage:

``` sql
update states_table
set the_geom = CDB_AlbersUSA(the_geom,state_identifier)
```

Produces a map like this:

<img width="782" alt="screen shot 2015-09-28 at 21 56 55" src="https://cloud.githubusercontent.com/assets/1041056/10155575/e142a8ce-662b-11e5-88d4-e98792563abe.png">

I'm looking for feedback on:
1. Choosing appropriate projections
2. Placement and scale of the states
3. Whether more state identifiers should be listed for the second argument

cc @makella @andrewxhill 
