### PR TITLE
Fix function declaration for create_from_unpackaged.sh use

### DIFF
--- a/scripts-available/CDB_Overviews.sql
+++ b/scripts-available/CDB_Overviews.sql
@@ -642,11 +642,7 @@ $$ LANGUAGE PLPGSQL;
 --                    created by the strategy must have the same columns
 --                    as the base table and in the same order.
 -- Return value: Array with the names of the generated overview tables
-CREATE OR REPLACE FUNCTION CDB_CreateOverviews(
-  reloid REGCLASS,
-  refscale_strategy regproc DEFAULT '_CDB_Feature_Density_Ref_Z_Strategy'::regproc,
-  reduce_strategy   regproc DEFAULT '_CDB_GridCluster_Reduce_Strategy'::regproc
-)
+CREATE OR REPLACE FUNCTION CDB_CreateOverviews(reloid REGCLASS, refscale_strategy regproc DEFAULT '_CDB_Feature_Density_Ref_Z_Strategy'::regproc, reduce_strategy regproc DEFAULT '_CDB_GridCluster_Reduce_Strategy'::regproc)
 RETURNS text[]
 AS $$
 DECLARE


### PR DESCRIPTION
This is a bugfix for version 0.13. It had a problem that affected the tests of cartodb.

In the CartoDB/cartodb tests, when a test user db is created, first a
`CREATE EXTENSION ... FROM unpackaged`
is tried to load the extension, and if it fails a regular `CREATE EXTENSION` is used.

The `create_from_unpackaged.sh` script produces an syntactically incorrect migration file from unpackaged when function parameter lists are not in a single line. Under that situation, the
`CREATE... FROM upackaged` in the CartoDB/cartodb tests fails in an unexpected way
(syntax error) and the extension is not correctly loaded for the test user. 
