### PR TITLE
[WIP] Add CDB_ForeignTable management functions

### DIFF
--- a/scripts-available/CDB_Conf.sql
+++ b/scripts-available/CDB_Conf.sql
@@ -5,44 +5,44 @@
 -- Functions needing reading configuration should use SECURITY DEFINER.
 ----------------------------------
 
--- This will trigger NOTICE if cartodb.CDB_CONF already exists
+-- This will trigger NOTICE if CDB_CONF already exists
 DO LANGUAGE 'plpgsql' $$
 BEGIN
-    CREATE TABLE IF NOT EXISTS cartodb.CDB_CONF ( KEY TEXT PRIMARY KEY, VALUE JSON NOT NULL );
+    CREATE TABLE IF NOT EXISTS CDB_CONF ( KEY TEXT PRIMARY KEY, VALUE JSON NOT NULL );
 END
 $$;
 
 -- This can only be called from an SQL script executed by CREATE EXTENSION
 DO LANGUAGE 'plpgsql' $$
 BEGIN
-    PERFORM pg_catalog.pg_extension_config_dump('cartodb.CDB_CONF', '');
+    PERFORM pg_catalog.pg_extension_config_dump('CDB_CONF', '');
 END
 $$;
 
 CREATE OR REPLACE
-FUNCTION cartodb.CDB_Conf_SetConf(key text, value JSON)
+FUNCTION CDB_Conf_SetConf(key text, value JSON)
     RETURNS void AS $$
 BEGIN
-    PERFORM cartodb.CDB_Conf_RemoveConf(key);
-    EXECUTE 'INSERT INTO cartodb.CDB_CONF (KEY, VALUE) VALUES ($1, $2);' USING key, value;
+    PERFORM CDB_Conf_RemoveConf(key);
+    EXECUTE 'INSERT INTO CDB_CONF (KEY, VALUE) VALUES ($1, $2);' USING key, value;
 END
 $$ LANGUAGE PLPGSQL VOLATILE;
 
 CREATE OR REPLACE
-FUNCTION cartodb.CDB_Conf_RemoveConf(key text)
+FUNCTION CDB_Conf_RemoveConf(key text)
     RETURNS void AS $$
 BEGIN
-    EXECUTE 'DELETE FROM cartodb.CDB_CONF WHERE KEY = $1;' USING key;
+    EXECUTE 'DELETE FROM CDB_CONF WHERE KEY = $1;' USING key;
 END
 $$ LANGUAGE PLPGSQL VOLATILE;
 
 CREATE OR REPLACE
-FUNCTION cartodb.CDB_Conf_GetConf(key text)
+FUNCTION CDB_Conf_GetConf(key text)
     RETURNS JSON AS $$
 DECLARE
     value JSON;
 BEGIN
-    EXECUTE 'SELECT VALUE FROM cartodb.CDB_CONF WHERE KEY = $1;' INTO value USING key;
+    EXECUTE 'SELECT VALUE FROM CDB_CONF WHERE KEY = $1;' INTO value USING key;
     RETURN value;
 END
 $$ LANGUAGE PLPGSQL STABLE;

--- a/scripts-available/CDB_ForeignTable.sql
+++ b/scripts-available/CDB_ForeignTable.sql
@@ -4,7 +4,7 @@
 -- All the FDW settings are read from the `cdb_conf.fdws` entry json file.
 ---------------------------
 
-CREATE OR REPLACE FUNCTION cartodb._CDB_Create_FDW(name text, config json)
+CREATE OR REPLACE FUNCTION cartodb._CDB_Setup_FDW(fdw_name text, config json)
 RETURNS void
 AS $$
 DECLARE
@@ -12,55 +12,49 @@ DECLARE
   option record;
   org_role text;
 BEGIN
-  IF NOT EXISTS ( SELECT * FROM pg_extension WHERE extname = 'postgres_fdw') 
-    THEN
+  -- This function tries to be as idempotent as possible, by not creating anything more than once
+  -- (not even using IF NOT EXIST to avoid throwing warnings)
+  IF NOT EXISTS ( SELECT * FROM pg_extension WHERE extname = 'postgres_fdw') THEN
     CREATE EXTENSION postgres_fdw;
   END IF;
-  -- This function is idempotent
   -- Create FDW first if it does not exist
-  IF NOT EXISTS ( SELECT * FROM pg_foreign_server WHERE srvname = name)
+  IF NOT EXISTS ( SELECT * FROM pg_foreign_server WHERE srvname = fdw_name)
     THEN
-    EXECUTE FORMAT('CREATE SERVER %I FOREIGN DATA WRAPPER postgres_fdw ',
-      name);
+    EXECUTE FORMAT('CREATE SERVER %I FOREIGN DATA WRAPPER postgres_fdw', fdw_name);
   END IF;
 
   -- Set FDW settings
   FOR row IN SELECT p.key, p.value from lateral json_each_text(config->'server') p
     LOOP
-      IF NOT EXISTS (WITH a AS (select split_part(unnest(srvoptions), '=', 1) as options from pg_foreign_server where srvname=name) SELECT * from a where options = row.key)
+      IF NOT EXISTS (WITH a AS (select split_part(unnest(srvoptions), '=', 1) as options from pg_foreign_server where srvname=fdw_name) SELECT * from a where options = row.key)
         THEN
-        EXECUTE FORMAT('ALTER SERVER %I OPTIONS (ADD %I %L)', name, row.key, row.value);
+        EXECUTE FORMAT('ALTER SERVER %I OPTIONS (ADD %I %L)', fdw_name, row.key, row.value);
       ELSE
-        EXECUTE FORMAT('ALTER SERVER %I OPTIONS (SET %I %L)', name, row.key, row.value);
+        EXECUTE FORMAT('ALTER SERVER %I OPTIONS (SET %I %L)', fdw_name, row.key, row.value);
       END IF;
     END LOOP;
 
     -- Create user mappings
-    FOR row IN SELECT p.key, p.value from lateral json_each(config->'users') p
-      LOOP 
+    FOR row IN SELECT p.key, p.value from lateral json_each(config->'users') p LOOP
         -- Check if entry on pg_user_mappings exists
 
-        IF NOT EXISTS ( SELECT * FROM pg_user_mappings WHERE srvname = name AND usename = row.key )
-          THEN
-          EXECUTE FORMAT ('CREATE USER MAPPING FOR %I SERVER %I', row.key, name);
+        IF NOT EXISTS ( SELECT * FROM pg_user_mappings WHERE srvname = name AND usename = row.key ) THEN
+          EXECUTE FORMAT ('CREATE USER MAPPING FOR %I SERVER %I', row.key, fdw_name);
         END IF;
 
     -- Update user mapping settings
-    FOR option IN SELECT o.key, o.value from lateral json_each_text(row.value) o
-      LOOP
-        IF NOT EXISTS (WITH a AS (select split_part(unnest(umoptions), '=', 1) as options from pg_user_mappings WHERE srvname = name AND usename = row.key) SELECT * from a where options = option.key)
-          THEN
-          EXECUTE FORMAT('ALTER USER MAPPING FOR %I SERVER %I OPTIONS (ADD %I %L)', row.key, name, option.key, option.value);
+    FOR option IN SELECT o.key, o.value from lateral json_each_text(row.value) o LOOP
+        IF NOT EXISTS (WITH a AS (select split_part(unnest(umoptions), '=', 1) as options from pg_user_mappings WHERE srvname = name AND usename = row.key) SELECT * from a where options = option.key) THEN
+          EXECUTE FORMAT('ALTER USER MAPPING FOR %I SERVER %I OPTIONS (ADD %I %L)', row.key, fdw_name, option.key, option.value);
         ELSE
-          EXECUTE FORMAT('ALTER USER MAPPING FOR %I SERVER %I OPTIONS (SET %I %L)', row.key, name, option.key, option.value);
+          EXECUTE FORMAT('ALTER USER MAPPING FOR %I SERVER %I OPTIONS (SET %I %L)', row.key, fdw_name, option.key, option.value);
         END IF;
       END LOOP;
     END LOOP;
 
     -- Create schema if it does not exist.
-    IF NOT EXISTS ( SELECT * from pg_namespace WHERE nspname=name)
-      THEN
-      EXECUTE FORMAT ('CREATE SCHEMA %I', name);
+    IF NOT EXISTS ( SELECT * from pg_namespace WHERE nspname=fdw_name) THEN
+      EXECUTE FORMAT ('CREATE SCHEMA %I', fdw_name);
     END IF;
 
     -- Give the organization role usage permisions over the schema
@@ -68,55 +62,49 @@ BEGIN
     EXECUTE FORMAT ('GRANT USAGE ON SCHEMA %I TO %I', name, org_role);
 
     -- Bring here the remote cdb_tablemetadata
-    IF NOT EXISTS ( SELECT * FROM PG_CLASS WHERE relnamespace = (SELECT oid FROM pg_namespace WHERE nspname='do') and relname='cdb_tablemetadata') 
-      THEN
-      EXECUTE FORMAT ('IMPORT FOREIGN SCHEMA cartodb LIMIT TO (cdb_tablemetadata) FROM SERVER %I INTO %I;', name, name, name);
+    IF NOT EXISTS ( SELECT * FROM PG_CLASS WHERE relnamespace = (SELECT oid FROM pg_namespace WHERE nspname='do') and relname='cdb_tablemetadata') THEN
+      EXECUTE FORMAT ('IMPORT FOREIGN SCHEMA cartodb LIMIT TO (cdb_tablemetadata) FROM SERVER %I INTO %I;', fdw_name, fdw_name, fdw_name);
     END IF;
-    EXECUTE FORMAT ('GRANT SELECT ON %I.cdb_tablemetadata TO %I', name, org_role);
+    EXECUTE FORMAT ('GRANT SELECT ON %I.cdb_tablemetadata TO %I', fdw_name, org_role);
 
 END
 $$
 LANGUAGE PLPGSQL;
 
-CREATE OR REPLACE FUNCTION cartodb._CDB_Create_FDWS()
+CREATE OR REPLACE FUNCTION cartodb._CDB_Setup_FDWS()
 RETURNS VOID AS 
 $$
 DECLARE
 row record;
 BEGIN
-  FOR row IN SELECT p.key, p.value from lateral json_each(cartodb.CDB_Conf_GetConf('fdws')) p
-    LOOP
-      EXECUTE 'SELECT cartodb._CDB_Create_FDW($1, $2)' USING row.key, row.value;
+  FOR row IN SELECT p.key, p.value from lateral json_each(cartodb.CDB_Conf_GetConf('fdws')) p LOOP
+      EXECUTE 'SELECT cartodb._CDB_Setup_FDW($1, $2)' USING row.key, row.value;
     END LOOP;
   END
-  $$
-  LANGUAGE PLPGSQL;
+$$
+LANGUAGE PLPGSQL;
 
 
-CREATE OR REPLACE FUNCTION cartodb._CDB_Create_FDW(name text)
+CREATE OR REPLACE FUNCTION cartodb._CDB_Setup_FDW(fdw_name text)
   RETURNS void AS
 $BODY$
 DECLARE
 config json;
 BEGIN
-  SELECT p.value FROM LATERAL json_each(cartodb.CDB_Conf_GetConf('fdws')) p WHERE p.key = name INTO config;
-  EXECUTE 'SELECT cartodb._CDB_Create_FDW($1, $2)' USING name, config;
+  SELECT p.value FROM LATERAL json_each(cartodb.CDB_Conf_GetConf('fdws')) p WHERE p.key = fdw_name INTO config;
+  EXECUTE 'SELECT cartodb._CDB_Setup_FDW($1, $2)' USING fdw_name, config;
 END
 $BODY$
-LANGUAGE plpgsql VOLATILE
-SECURITY DEFINER;
+LANGUAGE plpgsql VOLATILE;
 
 CREATE OR REPLACE FUNCTION cartodb.CDB_Add_Remote_Table(source text, table_name text)
-RETURNS void AS
+  RETURNS void AS
 $$
 BEGIN
-PERFORM cartodb._CDB_Create_FDW(source);
-EXECUTE FORMAT ('IMPORT FOREIGN SCHEMA %I LIMIT TO (%I) FROM SERVER %I INTO %I;', source, table_name, source, source);
---- Grant SELECT to publicuser
-EXECUTE FORMAT ('GRANT SELECT ON %I.%I TO publicuser;', source, table_name);
-
+  PERFORM cartodb._CDB_Setup_FDW(source);
+  EXECUTE FORMAT ('IMPORT FOREIGN SCHEMA %I LIMIT TO (%I) FROM SERVER %I INTO %I;', source, table_name, source, source);
+  --- Grant SELECT to publicuser
+  EXECUTE FORMAT ('GRANT SELECT ON %I.%I TO publicuser;', source, table_name);
 END
 $$
-LANGUAGE plpgsql
-security definer;
-
+LANGUAGE plpgsql;

--- a/scripts-available/CDB_ForeignTable.sql
+++ b/scripts-available/CDB_ForeignTable.sql
@@ -125,7 +125,7 @@ BEGIN
 
   -- We assume that the remote cdb_tablemetadata is called cdb_tablemetadata and is on the same schema as the queried table.
   SELECT nspname FROM pg_class c, pg_namespace n WHERE c.oid=foreign_table AND c.relnamespace = n.oid INTO fdw_schema_name;
-  EXECUTE FORMAT('SELECT updated_at FROM %I.cdb_tablemetadata WHERE tabname::text=%L ORDER BY updated_at DESC LIMIT 1', fdw_schema_name, remote_table_name) INTO time
+  EXECUTE FORMAT('SELECT updated_at FROM %I.cdb_tablemetadata WHERE tabname::text=%L ORDER BY updated_at DESC LIMIT 1', fdw_schema_name, remote_table_name) INTO time;
   RETURN time;
 END
 $$

--- a/scripts-available/CDB_ForeignTable.sql
+++ b/scripts-available/CDB_ForeignTable.sql
@@ -92,6 +92,20 @@ BEGIN
   $$
   LANGUAGE PLPGSQL;
 
+
+CREATE OR REPLACE FUNCTION cartodb._CDB_Create_FDW(name text)
+  RETURNS void AS
+$BODY$
+DECLARE
+config json;
+BEGIN
+  SELECT p.value FROM LATERAL json_each(cartodb.CDB_Conf_GetConf('fdws')) p WHERE p.key = name INTO config;
+  EXECUTE 'SELECT cartodb._CDB_Create_FDW($1, $2)' USING name, config;
+END
+$BODY$
+LANGUAGE plpgsql VOLATILE
+SECURITY DEFINER;
+
 CREATE OR REPLACE FUNCTION cartodb.CDB_Add_Remote_Table(source text, table_name text)
 RETURNS void AS
 $$

--- a/scripts-available/CDB_ForeignTable.sql
+++ b/scripts-available/CDB_ForeignTable.sql
@@ -63,7 +63,7 @@ BEGIN
 
     -- Bring here the remote cdb_tablemetadata
     IF NOT EXISTS ( SELECT * FROM PG_CLASS WHERE relnamespace = (SELECT oid FROM pg_namespace WHERE nspname=fdw_name) and relname='cdb_tablemetadata') THEN
-      EXECUTE FORMAT ('IMPORT FOREIGN SCHEMA cartodb LIMIT TO (cdb_tablemetadata) FROM SERVER %I INTO %I;', fdw_name, fdw_name, fdw_name);
+      EXECUTE FORMAT ('CREATE FOREIGN TABLE %I.cdb_tablemetadata (tabname regclass, updated_at timestamp with time zone) SERVER %I OPTIONS (table_name ''cdb_tablemetadata'', schema_name ''public'', updatable ''false'')', fdw_name, fdw_name);
     END IF;
     EXECUTE FORMAT ('GRANT SELECT ON %I.cdb_tablemetadata TO %I', fdw_name, org_role);
 

--- a/scripts-available/CDB_ForeignTable.sql
+++ b/scripts-available/CDB_ForeignTable.sql
@@ -1,0 +1,108 @@
+---------------------------
+-- FDW MANAGEMENT FUNCTIONS
+--
+-- All the FDW settings are read from the `cdb_conf.fdws` entry json file.
+---------------------------
+
+CREATE OR REPLACE FUNCTION cartodb._CDB_Create_FDW(name text, config json)
+RETURNS void
+AS $$
+DECLARE
+  row record;
+  option record;
+  org_role text;
+BEGIN
+  IF NOT EXISTS ( SELECT * FROM pg_extension WHERE extname = 'postgres_fdw') 
+    THEN
+    CREATE EXTENSION postgres_fdw;
+  END IF;
+  -- This function is idempotent
+  -- Create FDW first if it does not exist
+  IF NOT EXISTS ( SELECT * FROM pg_foreign_server WHERE srvname = name)
+    THEN
+    EXECUTE FORMAT('CREATE SERVER %I FOREIGN DATA WRAPPER postgres_fdw ',
+      name);
+  END IF;
+
+  -- Set FDW settings
+  FOR row IN SELECT p.key, p.value from lateral json_each_text(config->'server') p
+    LOOP
+      IF NOT EXISTS (WITH a AS (select split_part(unnest(srvoptions), '=', 1) as options from pg_foreign_server where srvname=name) SELECT * from a where options = row.key)
+        THEN
+        EXECUTE FORMAT('ALTER SERVER %I OPTIONS (ADD %I %L)', name, row.key, row.value);
+      ELSE
+        EXECUTE FORMAT('ALTER SERVER %I OPTIONS (SET %I %L)', name, row.key, row.value);
+      END IF;
+    END LOOP;
+
+    -- Create user mappings
+    FOR row IN SELECT p.key, p.value from lateral json_each(config->'users') p
+      LOOP 
+        -- Check if entry on pg_user_mappings exists
+
+        IF NOT EXISTS ( SELECT * FROM pg_user_mappings WHERE srvname = name AND usename = row.key )
+          THEN
+          EXECUTE FORMAT ('CREATE USER MAPPING FOR %I SERVER %I', row.key, name);
+        END IF;
+
+    -- Update user mapping settings
+    FOR option IN SELECT o.key, o.value from lateral json_each_text(row.value) o
+      LOOP
+        IF NOT EXISTS (WITH a AS (select split_part(unnest(umoptions), '=', 1) as options from pg_user_mappings WHERE srvname = name AND usename = row.key) SELECT * from a where options = option.key)
+          THEN
+          EXECUTE FORMAT('ALTER USER MAPPING FOR %I SERVER %I OPTIONS (ADD %I %L)', row.key, name, option.key, option.value);
+        ELSE
+          EXECUTE FORMAT('ALTER USER MAPPING FOR %I SERVER %I OPTIONS (SET %I %L)', row.key, name, option.key, option.value);
+        END IF;
+      END LOOP;
+    END LOOP;
+
+    -- Create schema if it does not exist.
+    IF NOT EXISTS ( SELECT * from pg_namespace WHERE nspname=name)
+      THEN
+      EXECUTE FORMAT ('CREATE SCHEMA %I', name);
+    END IF;
+
+    -- Give the organization role usage permisions over the schema
+    SELECT cartodb.CDB_Organization_Member_Group_Role_Member_Name() INTO org_role;
+    EXECUTE FORMAT ('GRANT USAGE ON SCHEMA %I TO %I', name, org_role);
+
+    -- Bring here the remote cdb_tablemetadata
+    IF NOT EXISTS ( SELECT * FROM PG_CLASS WHERE relnamespace = (SELECT oid FROM pg_namespace WHERE nspname='do') and relname='cdb_tablemetadata') 
+      THEN
+      EXECUTE FORMAT ('IMPORT FOREIGN SCHEMA cartodb LIMIT TO (cdb_tablemetadata) FROM SERVER %I INTO %I;', name, name, name);
+    END IF;
+    EXECUTE FORMAT ('GRANT SELECT ON %I.cdb_tablemetadata TO %I', name, org_role);
+
+END
+$$
+LANGUAGE PLPGSQL;
+
+CREATE OR REPLACE FUNCTION cartodb._CDB_Create_FDWS()
+RETURNS VOID AS 
+$$
+DECLARE
+row record;
+BEGIN
+  FOR row IN SELECT p.key, p.value from lateral json_each(cartodb.CDB_Conf_GetConf('fdws')) p
+    LOOP
+      EXECUTE 'SELECT cartodb._CDB_Create_FDW($1, $2)' USING row.key, row.value;
+    END LOOP;
+  END
+  $$
+  LANGUAGE PLPGSQL;
+
+CREATE OR REPLACE FUNCTION cartodb.CDB_Add_Remote_Table(source text, table_name text)
+RETURNS void AS
+$$
+BEGIN
+PERFORM cartodb._CDB_Create_FDW(source);
+EXECUTE FORMAT ('IMPORT FOREIGN SCHEMA %I LIMIT TO (%I) FROM SERVER %I INTO %I;', source, table_name, source, source);
+--- Grant SELECT to publicuser
+EXECUTE FORMAT ('GRANT SELECT ON %I.%I TO publicuser;', source, table_name);
+
+END
+$$
+LANGUAGE plpgsql
+security definer;
+

--- a/scripts-available/CDB_Organizations.sql
+++ b/scripts-available/CDB_Organizations.sql
@@ -1,5 +1,5 @@
 CREATE OR REPLACE
-FUNCTION cartodb.CDB_Organization_Member_Group_Role_Member_Name()
+FUNCTION CDB_Organization_Member_Group_Role_Member_Name()
     RETURNS TEXT
 AS $$
     SELECT 'cdb_org_member'::text || '_' || md5(current_database());
@@ -10,7 +10,7 @@ DO LANGUAGE 'plpgsql' $$
 DECLARE
     cdb_org_member_role_name TEXT;
 BEGIN
-  cdb_org_member_role_name := cartodb.CDB_Organization_Member_Group_Role_Member_Name();
+  cdb_org_member_role_name := CDB_Organization_Member_Group_Role_Member_Name();
   IF NOT EXISTS ( SELECT * FROM pg_roles WHERE rolname= cdb_org_member_role_name )
   THEN
     EXECUTE 'CREATE ROLE "' || cdb_org_member_role_name || '" NOLOGIN;';
@@ -19,11 +19,11 @@ END
 $$;
 
 CREATE OR REPLACE
-FUNCTION cartodb.CDB_Organization_Create_Member(role_name text)
+FUNCTION CDB_Organization_Create_Member(role_name text)
     RETURNS void
 AS $$
 BEGIN
-    EXECUTE 'GRANT "' || cartodb.CDB_Organization_Member_Group_Role_Member_Name() || '" TO "' || role_name || '"';
+    EXECUTE 'GRANT "' || CDB_Organization_Member_Group_Role_Member_Name() || '" TO "' || role_name || '"';
 END
 $$ LANGUAGE PLPGSQL VOLATILE;
 
@@ -31,7 +31,7 @@ $$ LANGUAGE PLPGSQL VOLATILE;
 -- Administrator
 -------------------------------------------------------------------------------
 CREATE OR REPLACE
-FUNCTION cartodb._CDB_Organization_Admin_Role_Name()
+FUNCTION _CDB_Organization_Admin_Role_Name()
     RETURNS TEXT
 AS $$
     SELECT current_database() || '_a'::text;
@@ -43,7 +43,7 @@ DO LANGUAGE 'plpgsql' $$
 DECLARE
     cdb_org_admin_role_name TEXT;
 BEGIN
-    cdb_org_admin_role_name := cartodb._CDB_Organization_Admin_Role_Name();
+    cdb_org_admin_role_name := _CDB_Organization_Admin_Role_Name();
     IF NOT EXISTS ( SELECT * FROM pg_roles WHERE rolname= cdb_org_admin_role_name )
     THEN
         EXECUTE format('CREATE ROLE %I CREATEROLE NOLOGIN;', cdb_org_admin_role_name);
@@ -52,15 +52,15 @@ END
 $$;
 
 CREATE OR REPLACE
-FUNCTION cartodb.CDB_Organization_AddAdmin(username text)
+FUNCTION CDB_Organization_AddAdmin(username text)
     RETURNS void
 AS $$
 DECLARE
     cdb_user_role TEXT;
     cdb_admin_role TEXT;
 BEGIN
-    cdb_admin_role := cartodb._CDB_Organization_Admin_Role_Name();
-    cdb_user_role := cartodb._CDB_User_RoleFromUsername(username);
+    cdb_admin_role := _CDB_Organization_Admin_Role_Name();
+    cdb_user_role := _CDB_User_RoleFromUsername(username);
     EXECUTE format('GRANT %I TO %I WITH ADMIN OPTION', cdb_admin_role, cdb_user_role);
     -- CREATEROLE is not inherited, and is needed for user creation
     EXECUTE format('ALTER ROLE %I CREATEROLE', cdb_user_role);
@@ -68,15 +68,15 @@ END
 $$ LANGUAGE PLPGSQL;
 
 CREATE OR REPLACE
-FUNCTION cartodb.CDB_Organization_RemoveAdmin(username text)
+FUNCTION CDB_Organization_RemoveAdmin(username text)
     RETURNS void
 AS $$
 DECLARE
     cdb_user_role TEXT;
     cdb_admin_role TEXT;
 BEGIN
-    cdb_admin_role := cartodb._CDB_Organization_Admin_Role_Name();
-    cdb_user_role := cartodb._CDB_User_RoleFromUsername(username);
+    cdb_admin_role := _CDB_Organization_Admin_Role_Name();
+    cdb_user_role := _CDB_User_RoleFromUsername(username);
     EXECUTE format('ALTER ROLE %I NOCREATEROLE', cdb_user_role);
     EXECUTE format('REVOKE %I FROM %I', cdb_admin_role, cdb_user_role);
 END
@@ -86,7 +86,7 @@ $$ LANGUAGE PLPGSQL;
 -- Sharing tables
 -------------------------------------------------------------------------------
 CREATE OR REPLACE
-FUNCTION cartodb.CDB_Organization_Add_Table_Read_Permission(from_schema text, table_name text, to_role_name text)
+FUNCTION CDB_Organization_Add_Table_Read_Permission(from_schema text, table_name text, to_role_name text)
     RETURNS void
 AS $$
 BEGIN
@@ -96,16 +96,16 @@ END
 $$ LANGUAGE PLPGSQL VOLATILE;
 
 CREATE OR REPLACE
-FUNCTION cartodb.CDB_Organization_Add_Table_Organization_Read_Permission(from_schema text, table_name text)
+FUNCTION CDB_Organization_Add_Table_Organization_Read_Permission(from_schema text, table_name text)
     RETURNS void
 AS $$
 BEGIN
-    EXECUTE 'SELECT cartodb.CDB_Organization_Add_Table_Read_Permission(''' || from_schema || ''', ''' || table_name || ''', ''' || cartodb.CDB_Organization_Member_Group_Role_Member_Name() || ''');';
+    EXECUTE 'SELECT CDB_Organization_Add_Table_Read_Permission(''' || from_schema || ''', ''' || table_name || ''', ''' || CDB_Organization_Member_Group_Role_Member_Name() || ''');';
 END
 $$ LANGUAGE PLPGSQL VOLATILE;
 
 CREATE OR REPLACE
-FUNCTION cartodb.CDB_Organization_Add_Table_Read_Write_Permission(from_schema text, table_name text, to_role_name text)
+FUNCTION CDB_Organization_Add_Table_Read_Write_Permission(from_schema text, table_name text, to_role_name text)
     RETURNS void
 AS $$
 BEGIN
@@ -115,17 +115,17 @@ END
 $$ LANGUAGE PLPGSQL VOLATILE;
 
 CREATE OR REPLACE
-FUNCTION cartodb.CDB_Organization_Add_Table_Organization_Read_Write_Permission(from_schema text, table_name text)
+FUNCTION CDB_Organization_Add_Table_Organization_Read_Write_Permission(from_schema text, table_name text)
     RETURNS void
 AS $$
 BEGIN
-    EXECUTE 'SELECT cartodb.CDB_Organization_Add_Table_Read_Write_Permission(''' || from_schema || ''', ''' || table_name || ''', ''' || cartodb.CDB_Organization_Member_Group_Role_Member_Name() || ''');';
+    EXECUTE 'SELECT CDB_Organization_Add_Table_Read_Write_Permission(''' || from_schema || ''', ''' || table_name || ''', ''' || CDB_Organization_Member_Group_Role_Member_Name() || ''');';
 END
 $$ LANGUAGE PLPGSQL VOLATILE;
 
 
 CREATE OR REPLACE
-FUNCTION cartodb.CDB_Organization_Remove_Access_Permission(from_schema text, table_name text, to_role_name text)
+FUNCTION CDB_Organization_Remove_Access_Permission(from_schema text, table_name text, to_role_name text)
     RETURNS void
 AS $$
 BEGIN
@@ -137,10 +137,10 @@ END
 $$ LANGUAGE PLPGSQL VOLATILE;
 
 CREATE OR REPLACE
-FUNCTION cartodb.CDB_Organization_Remove_Organization_Access_Permission(from_schema text, table_name text)
+FUNCTION CDB_Organization_Remove_Organization_Access_Permission(from_schema text, table_name text)
     RETURNS void
 AS $$
 BEGIN
-    EXECUTE 'SELECT cartodb.CDB_Organization_Remove_Access_Permission(''' || from_schema || ''', ''' || table_name || ''', ''' || cartodb.CDB_Organization_Member_Group_Role_Member_Name() || ''');';
+    EXECUTE 'SELECT CDB_Organization_Remove_Access_Permission(''' || from_schema || ''', ''' || table_name || ''', ''' || CDB_Organization_Member_Group_Role_Member_Name() || ''');';
 END
 $$ LANGUAGE PLPGSQL VOLATILE;

--- a/scripts-enabled/250-CDB_ForeignTable.sql
+++ b/scripts-enabled/250-CDB_ForeignTable.sql
@@ -1,0 +1,1 @@
+../scripts-available/CDB_ForeignTable.sql

--- a/test/extension/test.sh
+++ b/test/extension/test.sh
@@ -483,7 +483,7 @@ function test_foreign_tables() {
 ORDER BY 1, 2" should "test_fdw|cdb_tablemetadata|test_fdw
 test_fdw|foo|test_fdw"
 
-    sql postgres "SELECT cartodb.CDB_Get_Foreign_Updated_At('test_fdw.foo'::regclass) < NOW()" should 't'
+    sql postgres "SELECT CDB_Get_Foreign_Updated_At('test_fdw.foo'::regclass) < NOW()" should 't'
 
     sql postgres "SELECT a from test_fdw.foo LIMIT 1;" should 42
 
@@ -492,14 +492,14 @@ test_fdw|foo|test_fdw"
     sql postgres 'INSERT INTO local (b) VALUES (43);'
     sql postgres "SELECT cdb_tablemetadatatouch('public.local'::regclass);"
     local query='$query$ SELECT * FROM test_fdw.foo, local $query$::text'
-    sql postgres "SELECT dbname, schema_name, table_name FROM cartodb.CDB_QueryTables_Updated_At(${query}) ORDER BY dbname;" should 'fdw_target|test_fdw|foo
+    sql postgres "SELECT dbname, schema_name, table_name FROM CDB_QueryTables_Updated_At(${query}) ORDER BY dbname;" should 'fdw_target|test_fdw|foo
 test_extension|public|local'
-    sql postgres "SELECT table_name FROM cartodb.CDB_QueryTables_Updated_At(${query}) order by updated_at;" should 'foo
+    sql postgres "SELECT table_name FROM CDB_QueryTables_Updated_At(${query}) order by updated_at;" should 'foo
 local'
 
     # Check function CDB_Last_Updated_Time
-    sql postgres "SELECT cartodb.CDB_Last_Updated_Time('{test_fdw.foo,public.local}'::text[]) < now()" should 't'
-    sql postgres "SELECT cartodb.CDB_Last_Updated_Time('{test_fdw.foo,public.local}'::text[]) > (now() - interval '1 minute')" should 't'
+    sql postgres "SELECT CDB_Last_Updated_Time('{test_fdw.foo,public.local}'::text[]) < now()" should 't'
+    sql postgres "SELECT CDB_Last_Updated_Time('{test_fdw.foo,public.local}'::text[]) > (now() - interval '1 minute')" should 't'
 
     DATABASE=fdw_target sql postgres 'REVOKE USAGE ON SCHEMA test_fdw FROM fdw_user;'
     DATABASE=fdw_target sql postgres 'REVOKE SELECT ON test_fdw.foo FROM fdw_user;'

--- a/test/extension/test.sh
+++ b/test/extension/test.sh
@@ -462,7 +462,7 @@ function test_foreign_tables() {
     sql postgres "SELECT CDB_Conf_SetConf('fdws', '{\"test_fdw\": {\"server\": {\"host\": \"localhost\", \"dbname\": \"fdw_target\"},
                                            \"users\": {\"public\": {\"user\": \"fdw_user\", \"password\": \"foobarino\"}}}}')"
 
-    sql postgres "SELECT CDB_Setup_FDW('test_fdw')"
+    sql postgres "SELECT _CDB_Setup_FDW('test_fdw')"
 
     sql postgres "SHOW server_version_num"
     if [ "$RESULT" -gt 90499 ]

--- a/test/extension/test.sh
+++ b/test/extension/test.sh
@@ -459,15 +459,15 @@ function test_foreign_tables() {
 
     DATABASE=fdw_target sql postgres "SELECT cdb_tablemetadatatouch('test_fdw.foo'::regclass);"
 
-    sql postgres "SELECT cartodb.CDB_Conf_SetConf('fdws', '{\"test_fdw\": {\"server\": {\"host\": \"localhost\", \"dbname\": \"fdw_target\"},
+    sql postgres "SELECT CDB_Conf_SetConf('fdws', '{\"test_fdw\": {\"server\": {\"host\": \"localhost\", \"dbname\": \"fdw_target\"},
                                            \"users\": {\"public\": {\"user\": \"fdw_user\", \"password\": \"foobarino\"}}}}')"
 
-    sql postgres "SELECT cartodb._CDB_Setup_FDW('test_fdw')"
+    sql postgres "SELECT CDB_Setup_FDW('test_fdw')"
 
     sql postgres "SHOW server_version_num"
     if [ "$RESULT" -gt 90499 ]
     then
-        sql postgres "SELECT cartodb.CDB_Add_Remote_Table('test_fdw', 'foo')"
+        sql postgres "SELECT CDB_Add_Remote_Table('test_fdw', 'foo')"
         sql postgres "SELECT * from test_fdw.foo;"
     else
         echo "NOTICE: PostgreSQL version is less than 9.5 ($RESULT). Skipping CDB_Add_Remote_Table."

--- a/test/extension/test.sh
+++ b/test/extension/test.sh
@@ -172,8 +172,7 @@ function drop_raster_table() {
     sql ${ROLE} "DROP TABLE ${ROLE}.${TABLENAME};"
 }
 
-
-function setup() {
+function setup_database() {
     ${CMD} -c "CREATE DATABASE ${DATABASE}"
     sql "CREATE SCHEMA cartodb;"
     sql "GRANT USAGE ON SCHEMA cartodb TO public;"
@@ -184,7 +183,10 @@ function setup() {
     ${CMD} -d ${DATABASE} -f scripts-available/CDB_Organizations.sql
     # trick to allow forcing a schema when loading SQL files (see: http://bit.ly/1HeLnhL)
     ${CMD} -d ${DATABASE} -f test/extension/run_at_cartodb_schema.sql
+}
 
+function setup() {
+    setup_database
 
     log_info "############################# SETUP #############################"
     create_role_and_schema cdb_testmember_1
@@ -199,6 +201,10 @@ function setup() {
     sql cdb_testmember_2 'SELECT * FROM cdb_testmember_2.bar;'
 }
 
+
+function tear_down_database() {
+    ${CMD} -c "DROP DATABASE ${DATABASE}"
+}
 function tear_down() {
     log_info "########################### USER TEAR DOWN ###########################"
     sql cdb_testmember_1 "SELECT * FROM cartodb.CDB_Organization_Remove_Access_Permission('cdb_testmember_1', 'foo', 'cdb_testmember_2');"
@@ -219,8 +225,9 @@ function tear_down() {
     sql 'DROP ROLE cdb_testmember_1;'
     sql 'DROP ROLE cdb_testmember_2;'
 
-    ${CMD} -c "DROP DATABASE ${DATABASE}"
+    tear_down_database
 }
+
 
 function run_tests() {
     local FAILED_TESTS=()
@@ -427,6 +434,56 @@ function test_cdb_querytables_happy_cases() {
     sql postgres 'DROP TABLE "FOOBAR";'
     sql postgres 'DROP TABLE foo.wadus;'
     sql postgres 'DROP SCHEMA foo;'
+}
+
+function test_foreign_tables() {
+    ${CMD} -d ${DATABASE} -f scripts-available/CDB_QueryStatements.sql
+    ${CMD} -d ${DATABASE} -f scripts-available/CDB_QueryTables.sql
+    ${CMD} -d ${DATABASE} -f scripts-available/CDB_TableMetadata.sql
+    ${CMD} -d ${DATABASE} -f scripts-available/CDB_Conf.sql
+    ${CMD} -d ${DATABASE} -f scripts-available/CDB_ForeignTable.sql
+
+
+    DATABASE=fdw_target setup_database
+    ${CMD} -d fdw_target -f scripts-available/CDB_QueryStatements.sql
+    ${CMD} -d fdw_target -f scripts-available/CDB_QueryTables.sql
+    ${CMD} -d fdw_target -f scripts-available/CDB_TableMetadata.sql
+
+    DATABASE=fdw_target sql postgres 'CREATE SCHEMA test_fdw;'
+    DATABASE=fdw_target sql postgres 'CREATE TABLE test_fdw.foo (a int);'
+    DATABASE=fdw_target sql postgres 'INSERT INTO test_fdw.foo (a) values (42);'
+    DATABASE=fdw_target sql postgres "CREATE USER fdw_user WITH PASSWORD 'foobarino';"
+    DATABASE=fdw_target sql postgres 'GRANT USAGE ON SCHEMA test_fdw TO fdw_user;'
+    DATABASE=fdw_target sql postgres 'GRANT SELECT ON TABLE test_fdw.foo TO fdw_user;'
+    DATABASE=fdw_target sql postgres 'GRANT SELECT ON TABLE public.cdb_tablemetadata TO fdw_user;'
+
+    DATABASE=fdw_target sql postgres "SELECT cdb_tablemetadatatouch('test_fdw.foo'::regclass);"
+
+    sql postgres "SELECT CDB_Conf_SetConf('fdws', '{\"test_fdw\": {\"server\": {\"host\": \"localhost\", \"dbname\": \"fdw_target\"},
+                                           \"users\": {\"public\": {\"user\": \"fdw_user\", \"password\": \"foobarino\"}}}}')"
+
+    sql postgres "SELECT CDB_Add_Remote_Table('test_fdw', 'foo')"
+    sql postgres "SELECT * from test_fdw.foo;"
+    sql postgres "SELECT n.nspname,
+  c.relname,
+  s.srvname FROM pg_catalog.pg_foreign_table ft
+  INNER JOIN pg_catalog.pg_class c ON c.oid = ft.ftrelid
+  INNER JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+  INNER JOIN pg_catalog.pg_foreign_server s ON s.oid = ft.ftserver
+ORDER BY 1, 2" should "test_fdw|cdb_tablemetadata|test_fdw
+test_fdw|foo|test_fdw"
+
+    sql postgres "SELECT cartodb.CDB_Get_Foreign_Updated_At('test_fdw.foo'::regclass) < NOW()" should 't'
+
+    sql postgres "SELECT a from test_fdw.foo LIMIT 1;" should 42
+
+
+    DATABASE=fdw_target sql postgres 'REVOKE USAGE ON SCHEMA test_fdw FROM fdw_user;'
+    DATABASE=fdw_target sql postgres 'REVOKE SELECT ON test_fdw.foo FROM fdw_user;'
+    DATABASE=fdw_target sql postgres 'REVOKE SELECT ON cdb_tablemetadata FROM fdw_user;'
+    DATABASE=fdw_target sql postgres 'DROP ROLE fdw_user;'
+
+    DATABASE=fdw_target tear_down_database
 }
 
 #################################################### TESTS END HERE ####################################################

--- a/test/extension/test.sh
+++ b/test/extension/test.sh
@@ -459,10 +459,10 @@ function test_foreign_tables() {
 
     DATABASE=fdw_target sql postgres "SELECT cdb_tablemetadatatouch('test_fdw.foo'::regclass);"
 
-    sql postgres "SELECT CDB_Conf_SetConf('fdws', '{\"test_fdw\": {\"server\": {\"host\": \"localhost\", \"dbname\": \"fdw_target\"},
+    sql postgres "SELECT cartodb.CDB_Conf_SetConf('fdws', '{\"test_fdw\": {\"server\": {\"host\": \"localhost\", \"dbname\": \"fdw_target\"},
                                            \"users\": {\"public\": {\"user\": \"fdw_user\", \"password\": \"foobarino\"}}}}')"
 
-    sql postgres "SELECT CDB_Add_Remote_Table('test_fdw', 'foo')"
+    sql postgres "SELECT cartodb.CDB_Add_Remote_Table('test_fdw', 'foo')"
     sql postgres "SELECT * from test_fdw.foo;"
     sql postgres "SELECT n.nspname,
   c.relname,


### PR DESCRIPTION
So this is the first draft :sparkles: of how using `postgres_fdw` to access tables on other database (a CartoDB database) would work.

All of the magic comes from a json set in the CDB_Conf parameter `fdws`. It contains something like:

```
{  
   "foo":{  
      "server":{  
         "extensions":"postgis",
         "dbname":"cartodb_dev_user_7dfdbeff-97bc-4258-9fff-7bb55ced269e_db",
         "host":"localhost",
         "port":"5432"
      },
      "users":{  
         "public":{  
            "user":"fdw_foo_user",
            "password":"fdw_foo_pw123"
         }
      }
   }
}
```

With this, calling the function `_CDB_Create_FDW('foo');` will, given the enough permissions:
- Create the `FOREIGN SERVER`, called `foo`
- Set its parameters as according to the `server` properties
- Create a `USER MAPPING` for everybody in `users` (the "public" in this example is the origin user. Using "public" is a special user which is used as a default one by all users, not sure if we want to connect as anybody else) and set its properties.
- Create a `foo` schema.
- Grant permissions to use it to the organization role
- Bring the `cartodb.cdb_tablemetadata` remote table as `foo.cdb_tablemetadata`

This function is idempotent and can be ran as many times as desired - I've tried to verify for pre-existing things as much as possible (i.e check if the schema exists instead of running `CREATE SCHEMA IF NOT EXISTS`) to make it run always without any warnings for pre-existing things.

There's also the wrapper function `CDB_Add_Remote_Table('foo', 'provinces');`. This will setup the `foo` fdw and, afterwards, add the `provinces` table as the foreign table `foo.provinces`. (This one should not exist previously).
And it will also grant SELECT access to it to publicuser.


`CDB_Add_Remote_Table` has right now a security definer, so that any ordinary user can bring any remote table of a FDW an admin has configured for him. :sparkles:

This is a first PoC, probably the function names could change (Setup_FDW instead of Create_FDW to indicate the idempotency?). Some other pending concerns I can think of:
- Security: who do we want to give read access to the table? who should be able to call AddRemoteTable?. Need to review the permissions this needs / grants.
- Tests and doc :sparkles:, have to figure out a way to test/CI this.
- Compatibility: This does not use FDW table inheritance (per se) so it should work with 9.3. FDW extension pushdown (supported from 9.6 onward, or our backported 9.5) is only enabled when the "extension: postgres" is set on the config, so without it I believe it should work on 9.3, but that's something I'll figure out when I get to the tests.
- Oddities with using a foreign cdb_tablemetadata. postgres_fdw does some sort of remote OID to local OID translation, so that if you import cdb_tablemetadata only but have no tables it fails to cross-reference them like this:
```
cartodb_dev_user_6f72fe3d-6aee-413e-9cb7-0b4049c86dc2_db=# SELECT * FROM "do".cdb_tablemetadata;
ERROR:  relation "do.ign_spanish_adm3_municipalities" does not exist
CONTEXT:  column "tabname" of foreign table "cdb_tablemetadata"
```
But I'm not sure if querying the table for a specific table will work, it might do.

@javisantana @rafatower @rochoa 