### PR TITLE
Add CDB_TableMetadata_Text view as a proxy to access FDW tablemetadata

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,7 @@ $(EXTENSION)--$(EXTVERSION).sql: $(CDBSCRIPTS) cartodb_version.sql Makefile
 	echo '\echo Use "CREATE EXTENSION $(EXTENSION)" to load this file. \quit' > $@
 	cat $(CDBSCRIPTS) | \
     $(SED) -e 's/public\./cartodb./g' \
-        -e 's/:DATABASE_USERNAME/cdb_org_admin/g' >> $@
+        -e 's/:DATABASE_USERNAME/cdb_org_admin/g' \
         -e "s/''public''/''cartodb''/g" >> $@
 	echo "GRANT USAGE ON SCHEMA cartodb TO public;" >> $@
 	cat cartodb_version.sql >> $@

--- a/Makefile
+++ b/Makefile
@@ -93,6 +93,7 @@ $(EXTENSION)--$(EXTVERSION).sql: $(CDBSCRIPTS) cartodb_version.sql Makefile
 	cat $(CDBSCRIPTS) | \
     $(SED) -e 's/public\./cartodb./g' \
         -e 's/:DATABASE_USERNAME/cdb_org_admin/g' >> $@
+        -e "s/''public''/''cartodb''/g" >> $@
 	echo "GRANT USAGE ON SCHEMA cartodb TO public;" >> $@
 	cat cartodb_version.sql >> $@
 

--- a/scripts-available/CDB_ForeignTable.sql
+++ b/scripts-available/CDB_ForeignTable.sql
@@ -63,7 +63,7 @@ BEGIN
 
     -- Bring here the remote cdb_tablemetadata
     IF NOT EXISTS ( SELECT * FROM PG_CLASS WHERE relnamespace = (SELECT oid FROM pg_namespace WHERE nspname=fdw_name) and relname='cdb_tablemetadata') THEN
-      EXECUTE FORMAT ('CREATE FOREIGN TABLE %I.cdb_tablemetadata (tabname regclass, updated_at timestamp with time zone) SERVER %I OPTIONS (table_name ''cdb_tablemetadata'', schema_name ''public'', updatable ''false'')', fdw_name, fdw_name);
+      EXECUTE FORMAT ('CREATE FOREIGN TABLE %I.cdb_tablemetadata (tabname text, updated_at timestamp with time zone) SERVER %I OPTIONS (table_name ''cdb_tablemetadata_text'', schema_name ''public'', updatable ''false'')', fdw_name, fdw_name);
     END IF;
     EXECUTE FORMAT ('GRANT SELECT ON %I.cdb_tablemetadata TO %I', fdw_name, org_role);
 
@@ -125,7 +125,7 @@ BEGIN
 
   -- We assume that the remote cdb_tablemetadata is called cdb_tablemetadata and is on the same schema as the queried table.
   SELECT nspname FROM pg_class c, pg_namespace n WHERE c.oid=foreign_table AND c.relnamespace = n.oid INTO fdw_schema_name;
-  EXECUTE FORMAT('SELECT updated_at FROM %I.cdb_tablemetadata WHERE tabname::text=%L ORDER BY updated_at DESC LIMIT 1', fdw_schema_name, remote_table_name) INTO time;
+  EXECUTE FORMAT('SELECT updated_at FROM %I.cdb_tablemetadata WHERE tabname=%L ORDER BY updated_at DESC LIMIT 1', fdw_schema_name, remote_table_name) INTO time;
   RETURN time;
 END
 $$

--- a/scripts-available/CDB_ForeignTable.sql
+++ b/scripts-available/CDB_ForeignTable.sql
@@ -148,6 +148,7 @@ $$ LANGUAGE SQL;
 -- Return a set of (dbname, schema_name, table_name, updated_at)
 -- It is aware of foreign tables
 -- It assumes the local (schema_name, table_name) map to the remote ones with the same name
+-- Note: dbname is never quoted whereas schema and table names are when needed.
 CREATE OR REPLACE FUNCTION cartodb.CDB_QueryTables_Updated_At(query text)
 RETURNS TABLE(dbname text, schema_name text, table_name text, updated_at timestamptz)
 AS $$

--- a/scripts-available/CDB_TableMetadata.sql
+++ b/scripts-available/CDB_TableMetadata.sql
@@ -5,6 +5,11 @@ CREATE TABLE IF NOT EXISTS
     updated_at timestamp with time zone not null default now()
   );
 
+CREATE OR REPLACE VIEW public.CDB_TableMetadata_Text AS
+       SELECT FORMAT('%I.%I', n.nspname::text, c.relname::text) tabname, updated_at
+       FROM public.CDB_TableMetadata, pg_catalog.pg_class c
+       LEFT JOIN pg_catalog.pg_namespace n ON c.relnamespace = n.oid;
+
 -- No one can see this
 -- Updates are only possible trough the security definer trigger
 -- GRANT SELECT ON public.CDB_TableMetadata TO public;

--- a/test/extension/test.sh
+++ b/test/extension/test.sh
@@ -452,12 +452,16 @@ function test_foreign_tables() {
     DATABASE=fdw_target sql postgres 'CREATE SCHEMA test_fdw;'
     DATABASE=fdw_target sql postgres 'CREATE TABLE test_fdw.foo (a int);'
     DATABASE=fdw_target sql postgres 'INSERT INTO test_fdw.foo (a) values (42);'
+    DATABASE=fdw_target sql postgres 'CREATE TABLE test_fdw.foo2 (a int);'
+    DATABASE=fdw_target sql postgres 'INSERT INTO test_fdw.foo2 (a) values (42);'
     DATABASE=fdw_target sql postgres "CREATE USER fdw_user WITH PASSWORD 'foobarino';"
     DATABASE=fdw_target sql postgres 'GRANT USAGE ON SCHEMA test_fdw TO fdw_user;'
     DATABASE=fdw_target sql postgres 'GRANT SELECT ON TABLE test_fdw.foo TO fdw_user;'
-    DATABASE=fdw_target sql postgres 'GRANT SELECT ON TABLE public.cdb_tablemetadata TO fdw_user;'
+    DATABASE=fdw_target sql postgres 'GRANT SELECT ON TABLE test_fdw.foo2 TO fdw_user;'
+    DATABASE=fdw_target sql postgres 'GRANT SELECT ON cdb_tablemetadata_text TO fdw_user;'
 
     DATABASE=fdw_target sql postgres "SELECT cdb_tablemetadatatouch('test_fdw.foo'::regclass);"
+    DATABASE=fdw_target sql postgres "SELECT cdb_tablemetadatatouch('test_fdw.foo2'::regclass);"
 
     sql postgres "SELECT cartodb.CDB_Conf_SetConf('fdws', '{\"test_fdw\": {\"server\": {\"host\": \"localhost\", \"dbname\": \"fdw_target\"},
                                            \"users\": {\"public\": {\"user\": \"fdw_user\", \"password\": \"foobarino\"}}}}')"
@@ -516,9 +520,11 @@ test_extension|public|"local-table-with-dashes"'
 
     DATABASE=fdw_target sql postgres 'REVOKE USAGE ON SCHEMA test_fdw FROM fdw_user;'
     DATABASE=fdw_target sql postgres 'REVOKE SELECT ON test_fdw.foo FROM fdw_user;'
-    DATABASE=fdw_target sql postgres 'REVOKE SELECT ON cdb_tablemetadata FROM fdw_user;'
+    DATABASE=fdw_target sql postgres 'REVOKE SELECT ON test_fdw.foo2 FROM fdw_user;'
+    DATABASE=fdw_target sql postgres 'REVOKE SELECT ON cdb_tablemetadata_text FROM fdw_user;'
     DATABASE=fdw_target sql postgres 'DROP ROLE fdw_user;'
 
+    sql postgres "select pg_terminate_backend(pid) from pg_stat_activity where datname='fdw_target';"
     DATABASE=fdw_target tear_down_database
 }
 


### PR DESCRIPTION
`CDB_Get_Foreign_Updated_At` was assuming the `tabname::text` filter would be passed to the foreign backend, however the query planner decides sometimes that that filter is not worth pushing down and tries to fetch the whole table.

When doing so, it fails if there is a remote table that is not locally due to the regclass casting oddities:
```cartodb_dev_user_6f72fe3d-6aee-413e-9cb7-0b4049c86dc2_db=# explain analyze SELECT updated_at FROM "do".cdb_tablemetadata WHERE tabname::text='"do".ign_spanish_adm3_municipalities'::text LIMIT 1;
ERROR:  relation "do.ne_10m_admin_1_states_provinces_lines_shp" does not exist
CONTEXT:  column "tabname" of foreign table "cdb_tablemetadata"```

This introduces a new view `CDB_TableMetadata_Text` that has the contents of CDB_TableMetadata but casted to FQTN.

cc @rafatower