### PR TITLE
Remove casting to bigint in cartodb_id column

### DIFF
--- a/scripts-available/CDB_CartodbfyTable.sql
+++ b/scripts-available/CDB_CartodbfyTable.sql
@@ -919,7 +919,7 @@ BEGIN
 
   -- Add cartodb ID!
   IF has_usable_primary_key THEN
-    sql := sql || const.pkey || '::bigint ';
+    sql := sql || const.pkey || '::integer ';
   ELSE
     sql := sql || 'nextval(''' || destseq || ''') AS ' || const.pkey;
   END IF;


### PR DESCRIPTION
Fixes https://github.com/CartoDB/cartodb-postgresql/issues/209


We forced the casting to bigint thinking that every cartodb_id was created as a bigint, but it was not true and Rails tests made us notice.

For cartodbfycations of tables with an existent pk in cartodb_id, integer will be created, as everything is set up and manipulations on the column are not needed.

For cartodbfycations of tables without any cartodb_id at all, a bigint will be created due to the sequence that is assigned to it. `setval` and `nextval` return with bigints: http://www.postgresql.org/docs/9.4/static/functions-sequence.html

If we cast to `integer` instead, the support for text cartodb_id's will be still valid and it will not conflict with the legacy cartodb_id types.