### PR TITLE
Fix backslashes in generated files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -116,6 +116,9 @@ $(EXTENSION).control: $(EXTENSION).control.in Makefile
 cartodb_version.sql: cartodb_version.sql.in Makefile $(GITDIR)/index
 	$(SED) -e 's/@@VERSION@@/$(EXTVERSION)/' $< > $@
 
+# Needed for consistent `echo` results with backslashes
+SHELL = bash
+
 legacy_regress: $(REGRESS_OLD) Makefile
 	mkdir -p sql/test/
 	mkdir -p expected/test/
@@ -123,14 +126,14 @@ legacy_regress: $(REGRESS_OLD) Makefile
 	for f in $(REGRESS_OLD); do \
     tn=`basename $${f} .sql`; \
     of=sql/test/$${tn}.sql; \
-    echo '\\set ECHO none' > $${of}; \
-    echo '\\a' >> $${of}; \
-    echo '\\t' >> $${of}; \
-    echo '\\set QUIET off' >> $${of}; \
+    echo '\set ECHO none' > $${of}; \
+    echo '\a' >> $${of}; \
+    echo '\t' >> $${of}; \
+    echo '\set QUIET off' >> $${of}; \
     cat $${f} | \
       $(SED) -e 's/public\./cartodb./g' >> $${of}; \
     exp=expected/test/$${tn}.out; \
-    echo '\\set ECHO none' > $${exp}; \
+    echo '\set ECHO none' > $${exp}; \
     cat test/$${tn}_expect >> $${exp}; \
   done
 


### PR DESCRIPTION
Fixes #213
Some systems treat escaping of text passed to the echo command
from a Makefile differently.
This seems to work for our needs.