### PR TITLE
Fix AVG computation in overview tables

### DIFF
--- a/test/CDB_OverviewsTest_expect
+++ b/test/CDB_OverviewsTest_expect
@@ -12,8 +12,8 @@ SELECT 1114
 {_vovw_2_base_bare_t,_vovw_1_base_bare_t,_vovw_0_base_bare_t}
 126
 number,int_number,name,start
-AVG(number)::double precision AS number,AVG(int_number)::integer AS int_number,CASE count(*) WHEN 1 THEN MIN(name) ELSE NULL END::text AS name,CASE count(*) WHEN 1 THEN MIN(start) ELSE NULL END::date AS start
-AVG(tab.number)::double precision AS number,AVG(tab.int_number)::integer AS int_number,CASE count(*) WHEN 1 THEN MIN(tab.name) ELSE NULL END::text AS name,CASE count(*) WHEN 1 THEN MIN(tab.start) ELSE NULL END::date AS start
+SUM(number*1)/count(*)::double precision AS number,SUM(int_number*1)/count(*)::integer AS int_number,CASE count(*) WHEN 1 THEN MIN(name) ELSE NULL END::text AS name,CASE count(*) WHEN 1 THEN MIN(start) ELSE NULL END::date AS start
+SUM(tab.number*1)/count(*)::double precision AS number,SUM(tab.int_number*1)/count(*)::integer AS int_number,CASE count(*) WHEN 1 THEN MIN(tab.name) ELSE NULL END::text AS name,CASE count(*) WHEN 1 THEN MIN(tab.start) ELSE NULL END::date AS start
 {_vovw_2_base_t,_vovw_1_base_t,_vovw_0_base_t}
 126
 


### PR DESCRIPTION
Fixes #232
Averages of averages are not equal to overall averages.