### PR TITLE
Stats functions rewrite

### DIFF
--- a/scripts-available/CDB_Stats.sql
+++ b/scripts-available/CDB_Stats.sql
@@ -16,7 +16,7 @@ DECLARE
     s numeric;
     k numeric;
 BEGIN
-    SELECT AVG(e), COUNT(e)::numeric, stddev(e) INTO a, c, s FROM ( SELECT unnest(in_array) e ) x;
+    SELECT AVG(e), COUNT(e)::numeric, stddev_pop(e) INTO a, c, s FROM ( SELECT unnest(in_array) e ) x;
 
     EXECUTE 'SELECT sum(power($1 - e, 4)) / ( $2 * power($3, 4)) - 3
              FROM (SELECT unnest($4) e ) x'
@@ -35,7 +35,7 @@ DECLARE
     s numeric;
     sk numeric;
 BEGIN
-    SELECT AVG(e), COUNT(e)::numeric, stddev(e) INTO a, c, s FROM ( SELECT unnest(in_array) e ) x;
+    SELECT AVG(e), COUNT(e)::numeric, stddev_pop(e) INTO a, c, s FROM ( SELECT unnest(in_array) e ) x;
 
     EXECUTE 'SELECT sum(power($1 - e, 3)) / ( $2 * power($3, 3))
              FROM (SELECT unnest($4) e ) x'

--- a/scripts-available/CDB_Stats.sql
+++ b/scripts-available/CDB_Stats.sql
@@ -17,15 +17,61 @@
 -- This is more accurate than a single-pass calculating from raw moments, which
 -- accumlates floating point error badly.
 -- References: http://mathworld.wolfram.com/Kurtosis.html
-CREATE OR REPLACE FUNCTION CDB_Kurtosis ( in_array NUMERIC[] ) RETURNS NUMERIC as $$
+CREATE OR REPLACE FUNCTION CDB_Kurtosis ( in_array smallint[] ) RETURNS numeric as $$
 WITH pass1 AS (SELECT avg(x) a FROM (SELECT unnest(in_array) x) q) -- first pass calculate average
-SELECT avg(power(x-a, 4))/power(stddev_pop(x),4) - 3 FROM pass1, (SELECT unnest(in_array) x) q;
+SELECT (avg(power(x-a, 4))/power(stddev_pop(x),4) - 3)::numeric
+  FROM pass1, (SELECT unnest(in_array) x) q;
+$$ LANGUAGE SQL IMMUTABLE;
+CREATE OR REPLACE FUNCTION CDB_Kurtosis ( in_array int[] ) RETURNS numeric as $$
+WITH pass1 AS (SELECT avg(x) a FROM (SELECT unnest(in_array) x) q) -- first pass calculate average
+SELECT (avg(power(x-a, 4))/power(stddev_pop(x),4) - 3)::numeric
+  FROM pass1, (SELECT unnest(in_array) x) q;
+$$ LANGUAGE SQL IMMUTABLE;
+CREATE OR REPLACE FUNCTION CDB_Kurtosis ( in_array bigint[] ) RETURNS numeric as $$
+WITH pass1 AS (SELECT avg(x) a FROM (SELECT unnest(in_array) x) q) -- first pass calculate average
+SELECT (avg(power(x-a, 4))/power(stddev_pop(x),4) - 3)::numeric
+  FROM pass1, (SELECT unnest(in_array) x) q;
+$$ LANGUAGE SQL IMMUTABLE;
+CREATE OR REPLACE FUNCTION CDB_Kurtosis ( in_array real[] ) RETURNS double precision as $$
+WITH pass1 AS (SELECT avg(x) a FROM (SELECT unnest(in_array) x) q) -- first pass calculate average
+SELECT (avg(power(x-a, 4))/power(stddev_pop(x),4) - 3)::double precision
+  FROM pass1, (SELECT unnest(in_array) x) q;
+$$ LANGUAGE SQL IMMUTABLE;
+CREATE OR REPLACE FUNCTION CDB_Kurtosis ( in_array double precision[] ) RETURNS double precision as $$
+WITH pass1 AS (SELECT avg(x) a FROM (SELECT unnest(in_array) x) q) -- first pass calculate average
+SELECT (avg(power(x-a, 4))/power(stddev_pop(x),4) - 3)::double precision
+  FROM pass1, (SELECT unnest(in_array) x) q;
+$$ LANGUAGE SQL IMMUTABLE;
+CREATE OR REPLACE FUNCTION CDB_Kurtosis ( in_array numeric[] ) RETURNS numeric as $$
+WITH pass1 AS (SELECT avg(x) a FROM (SELECT unnest(in_array) x) q) -- first pass calculate average
+SELECT (avg(power(x-a, 4))/power(stddev_pop(x),4) - 3)::numeric
+  FROM pass1, (SELECT unnest(in_array) x) q;
 $$ LANGUAGE SQL IMMUTABLE;
 
 -- Calculate skewness
 -- This uses the same technique as CDB_Kurtosis, except with the 3rd central moment
 -- References: http://mathworld.wolfram.com/Skewness.html
-CREATE OR REPLACE FUNCTION CDB_Skewness ( in_array NUMERIC[] ) RETURNS NUMERIC as $$
+CREATE OR REPLACE FUNCTION CDB_Skewness ( in_array smallint[] ) RETURNS numeric as $$
 WITH pass1 AS (SELECT avg(x) a FROM (SELECT unnest(in_array) x) q) -- first pass calculate average
-SELECT avg(power(x-a, 3))/power(stddev_pop(x),3) FROM pass1, (SELECT unnest(in_array) x) q;
+SELECT (avg(power(x-a, 3))/power(stddev_pop(x),3))::numeric FROM pass1, (SELECT unnest(in_array) x) q;
+$$ LANGUAGE SQL IMMUTABLE;
+CREATE OR REPLACE FUNCTION CDB_Skewness ( in_array int[] ) RETURNS numeric as $$
+WITH pass1 AS (SELECT avg(x) a FROM (SELECT unnest(in_array) x) q) -- first pass calculate average
+SELECT (avg(power(x-a, 3))/power(stddev_pop(x),3))::numeric FROM pass1, (SELECT unnest(in_array) x) q;
+$$ LANGUAGE SQL IMMUTABLE;
+CREATE OR REPLACE FUNCTION CDB_Skewness ( in_array bigint[] ) RETURNS NUMERIC as $$
+WITH pass1 AS (SELECT avg(x) a FROM (SELECT unnest(in_array) x) q) -- first pass calculate average
+SELECT (avg(power(x-a, 3))/power(stddev_pop(x),3))::numeric FROM pass1, (SELECT unnest(in_array) x) q;
+$$ LANGUAGE SQL IMMUTABLE;
+CREATE OR REPLACE FUNCTION CDB_Skewness ( in_array real[] ) RETURNS double precision as $$
+WITH pass1 AS (SELECT avg(x) a FROM (SELECT unnest(in_array) x) q) -- first pass calculate average
+SELECT (avg(power(x-a, 3))/power(stddev_pop(x),3))::double precision FROM pass1, (SELECT unnest(in_array) x) q;
+$$ LANGUAGE SQL IMMUTABLE;
+CREATE OR REPLACE FUNCTION CDB_Skewness ( in_array double precision[] ) RETURNS double precision as $$
+WITH pass1 AS (SELECT avg(x) a FROM (SELECT unnest(in_array) x) q) -- first pass calculate average
+SELECT (avg(power(x-a, 3))/power(stddev_pop(x),3))::double precision FROM pass1, (SELECT unnest(in_array) x) q;
+$$ LANGUAGE SQL IMMUTABLE;
+CREATE OR REPLACE FUNCTION CDB_Skewness ( in_array numeric[] ) RETURNS numeric as $$
+WITH pass1 AS (SELECT avg(x) a FROM (SELECT unnest(in_array) x) q) -- first pass calculate average
+SELECT (avg(power(x-a, 3))/power(stddev_pop(x),3))::numeric FROM pass1, (SELECT unnest(in_array) x) q;
 $$ LANGUAGE SQL IMMUTABLE;

--- a/test/CDB_StatsTest.sql
+++ b/test/CDB_StatsTest.sql
@@ -6,8 +6,8 @@ WITH dist AS (
   SELECT generate_series(0,10000)::numeric / 10000.0 i
 )
 SELECT
-  abs(CDB_Kurtosis(array_agg(i)) + 1.2) < 1e-3 AS kurtosis,
-  abs(CDB_Skewness(array_agg(i))) < 1e-3 AS skewness
+  abs(CDB_Kurtosis(array_agg(i)) + 1.2) < 1e-6 AS kurtosis,
+  abs(CDB_Skewness(array_agg(i))) < 1e-6 AS skewness
 FROM dist;
 
 set client_min_messages to NOTICE;

--- a/test/CDB_StatsTest.sql
+++ b/test/CDB_StatsTest.sql
@@ -2,9 +2,32 @@
 -- http://mathworld.wolfram.com/UniformDistribution.html
 set client_min_messages to ERROR;
 
-WITH dist AS (
-  SELECT generate_series(0,10000)::numeric / 10000.0 i
-)
+WITH dist AS (SELECT generate_series(0,10000)::smallint / 10000.0 i)
+SELECT
+  abs(CDB_Kurtosis(array_agg(i)) + 1.2) < 1e-6 AS kurtosis,
+  abs(CDB_Skewness(array_agg(i))) < 1e-6 AS skewness
+FROM dist;
+WITH dist AS (SELECT generate_series(0,10000)::int / 10000.0 i)
+SELECT
+  abs(CDB_Kurtosis(array_agg(i)) + 1.2) < 1e-6 AS kurtosis,
+  abs(CDB_Skewness(array_agg(i))) < 1e-6 AS skewness
+FROM dist;
+WITH dist AS (SELECT generate_series(0,10000)::bigint / 10000.0 i)
+SELECT
+  abs(CDB_Kurtosis(array_agg(i)) + 1.2) < 1e-6 AS kurtosis,
+  abs(CDB_Skewness(array_agg(i))) < 1e-6 AS skewness
+FROM dist;
+WITH dist AS (SELECT generate_series(0,10000)::real / 10000.0 i)
+SELECT
+  abs(CDB_Kurtosis(array_agg(i)) + 1.2) < 1e-6 AS kurtosis,
+  abs(CDB_Skewness(array_agg(i))) < 1e-6 AS skewness
+FROM dist;
+WITH dist AS (SELECT generate_series(0,10000)::double precision / 10000.0 i)
+SELECT
+  abs(CDB_Kurtosis(array_agg(i)) + 1.2) < 1e-6 AS kurtosis,
+  abs(CDB_Skewness(array_agg(i))) < 1e-6 AS skewness
+FROM dist;
+WITH dist AS (SELECT generate_series(0,10000)::numeric / 10000.0 i)
 SELECT
   abs(CDB_Kurtosis(array_agg(i)) + 1.2) < 1e-6 AS kurtosis,
   abs(CDB_Skewness(array_agg(i))) < 1e-6 AS skewness

--- a/test/CDB_StatsTest_expect
+++ b/test/CDB_StatsTest_expect
@@ -1,3 +1,8 @@
 SET
 t|t
+t|t
+t|t
+t|t
+t|t
+t|t
 SET


### PR DESCRIPTION
- Switches to much shorter SQL implementations
- Fixes a bug with the wrong standard deviation being used
- Decreases tolerance for error on the tests
- Adds versions for all number types, not just numeric.

There is a minor (~10%) performance gain from the SQL version, but on a table with reals the new versions are over 4x faster.
