### PR TITLE
Use standard formula for CDB_ZoomFromScale

### DIFF
--- a/scripts-available/CDB_ZoomFromScale.sql
+++ b/scripts-available/CDB_ZoomFromScale.sql
@@ -1,30 +1,12 @@
-CREATE OR REPLACE FUNCTION cartodb.CDB_ZoomFromScale(scaleDenominator numeric) RETURNS int AS $$
-BEGIN
+CREATE OR REPLACE FUNCTION cartodb.CDB_ZoomFromScale(scaleDenominator numeric)
+RETURNS int
+LANGUAGE SQL
+IMMUTABLE
+AS $$
+SELECT
   CASE
-    WHEN scaleDenominator > 500000000 THEN RETURN 0;
-    WHEN scaleDenominator <= 500000000 AND scaleDenominator > 200000000 THEN RETURN 1;
-    WHEN scaleDenominator <= 200000000 AND scaleDenominator > 100000000 THEN RETURN 2;
-    WHEN scaleDenominator <= 100000000 AND scaleDenominator > 50000000 THEN RETURN 3;
-    WHEN scaleDenominator <= 50000000 AND scaleDenominator > 25000000 THEN RETURN 4;
-    WHEN scaleDenominator <= 25000000 AND scaleDenominator > 12500000 THEN RETURN 5;
-    WHEN scaleDenominator <= 12500000 AND scaleDenominator > 6500000 THEN RETURN 6;
-    WHEN scaleDenominator <= 6500000 AND scaleDenominator > 3000000 THEN RETURN 7;
-    WHEN scaleDenominator <= 3000000 AND scaleDenominator > 1500000 THEN RETURN 8;
-    WHEN scaleDenominator <= 1500000 AND scaleDenominator > 750000 THEN RETURN 9;
-    WHEN scaleDenominator <= 750000 AND scaleDenominator > 400000 THEN RETURN 10;
-    WHEN scaleDenominator <= 400000 AND scaleDenominator > 200000 THEN RETURN 11;
-    WHEN scaleDenominator <= 200000 AND scaleDenominator > 100000 THEN RETURN 12;
-    WHEN scaleDenominator <= 100000 AND scaleDenominator > 50000 THEN RETURN 13;
-    WHEN scaleDenominator <= 50000 AND scaleDenominator > 25000 THEN RETURN 14;
-    WHEN scaleDenominator <= 25000 AND scaleDenominator > 12500 THEN RETURN 15;
-    WHEN scaleDenominator <= 12500 AND scaleDenominator > 5000 THEN RETURN 16;
-    WHEN scaleDenominator <= 5000 AND scaleDenominator > 2500 THEN RETURN 17;
-    WHEN scaleDenominator <= 2500 AND scaleDenominator > 1500 THEN RETURN 18;
-    WHEN scaleDenominator <= 1500 AND scaleDenominator > 750 THEN RETURN 19;
-    WHEN scaleDenominator <= 750 AND scaleDenominator > 500 THEN RETURN 20;
-    WHEN scaleDenominator <= 500 AND scaleDenominator > 250 THEN RETURN 21;
-    WHEN scaleDenominator <= 250 AND scaleDenominator > 100 THEN RETURN 22;
-    WHEN scaleDenominator <= 100 THEN RETURN 23;
-  END CASE;
-END
-$$ LANGUAGE plpgsql IMMUTABLE;
+  -- Don't bother if the scale is larger than ~zoom level 0
+    WHEN scaleDenominator > 600000000 OR scaleDenominator = 0 THEN NULL
+    ELSE CAST (ROUND(LOG(2, 559082264.028/scaleDenominator)) AS INTEGER)
+  END;
+$$;

--- a/scripts-available/CDB_ZoomFromScale.sql
+++ b/scripts-available/CDB_ZoomFromScale.sql
@@ -17,11 +17,20 @@ RETURNS int
 LANGUAGE SQL
 IMMUTABLE
 AS $$
-SELECT
-  CASE
-    -- Don't bother if the scale is larger than ~zoom level 0
-    WHEN scaleDenominator > 600000000 OR scaleDenominator = 0 THEN NULL
-    WHEN scaleDenominator = 0 THEN _CDB_MaxSupportedZoom()
-    ELSE CAST (LEAST(ROUND(LOG(2, 559082264.028/scaleDenominator)), _CDB_MaxSupportedZoom()) AS INTEGER)
-  END;
+  SELECT
+    CASE
+      WHEN scaleDenominator > 600000000 THEN
+        -- Scale is smaller than zoom level 0
+        NULL
+      WHEN scaleDenominator = 0 THEN
+        -- Actual zoom level would be infinite
+        _CDB_MaxSupportedZoom()
+      ELSE
+        CAST (
+          LEAST(
+            ROUND(LOG(2, 559082264.028/scaleDenominator)),
+            _CDB_MaxSupportedZoom()
+          )
+        AS INTEGER)
+    END;
 $$;

--- a/scripts-available/CDB_ZoomFromScale.sql
+++ b/scripts-available/CDB_ZoomFromScale.sql
@@ -1,3 +1,17 @@
+-- Maximum supported zoom level
+CREATE OR REPLACE FUNCTION _CDB_MaxSupportedZoom()
+RETURNS int
+LANGUAGE SQL
+IMMUTABLE
+AS $$
+  -- The maximum zoom level has to be limited for various reasons,
+  -- e.g. zoom levels greater than 31 would require tile coordinates
+  -- that would not fit in an INTEGER (which is signed, 32 bits long).
+  -- We'll choose 20 as a limit which is safe also when the JavaScript shift
+  -- operator (<<) is used for computing powers of two.
+  SELECT 29;
+$$;
+
 CREATE OR REPLACE FUNCTION cartodb.CDB_ZoomFromScale(scaleDenominator numeric)
 RETURNS int
 LANGUAGE SQL
@@ -5,8 +19,9 @@ IMMUTABLE
 AS $$
 SELECT
   CASE
-  -- Don't bother if the scale is larger than ~zoom level 0
+    -- Don't bother if the scale is larger than ~zoom level 0
     WHEN scaleDenominator > 600000000 OR scaleDenominator = 0 THEN NULL
-    ELSE CAST (ROUND(LOG(2, 559082264.028/scaleDenominator)) AS INTEGER)
+    WHEN scaleDenominator = 0 THEN _CDB_MaxSupportedZoom()
+    ELSE CAST (LEAST(ROUND(LOG(2, 559082264.028/scaleDenominator)), _CDB_MaxSupportedZoom()) AS INTEGER)
   END;
 $$;


### PR DESCRIPTION
This comes from #197 

The maximum zoom, previously limited to 23 is now limited to a higher value, and is returned even
when the scale denominator is 0 (for which the actual level would be infinite) to avoid breaking
some cases where a 0 is used as a dummy scale denominator as here:
https://github.com/CartoDB/Windshaft/blob/2cd43d4b2ca2b3487ede8423f698b282c6e53af4/lib/windshaft/backends/attributes.js#L81

This would be a problem for example for the queries used for overview tables, which will yield no result for a null zoom level, causing that example to fail.
