### PR TITLE
Fix tests: race condition with publicuser #157

### DIFF
--- a/test/extension/test.sh
+++ b/test/extension/test.sh
@@ -227,6 +227,7 @@ function tear_down() {
     sql 'DROP ROLE cdb_testmember_2;'
 
     tear_down_database
+    DATABASE=postgres sql postgres 'DROP ROLE IF EXISTS publicuser';
 }
 
 
@@ -485,6 +486,18 @@ function test_foreign_tables() {
     ${CMD} -d fdw_target -f scripts-available/CDB_QueryTables.sql
     ${CMD} -d fdw_target -f scripts-available/CDB_TableMetadata.sql
 
+    DATABASE=fdw_target sql postgres "DO
+\$\$
+BEGIN
+   IF NOT EXISTS (
+      SELECT *
+      FROM   pg_catalog.pg_user
+      WHERE  usename = 'publicuser') THEN
+
+      CREATE ROLE publicuser LOGIN;
+   END IF;
+END
+\$\$;"
     DATABASE=fdw_target sql postgres 'CREATE SCHEMA test_fdw;'
     DATABASE=fdw_target sql postgres 'CREATE TABLE test_fdw.foo (a int);'
     DATABASE=fdw_target sql postgres 'INSERT INTO test_fdw.foo (a) values (42);'


### PR DESCRIPTION
There's a test race between the `test/extension/test.sh` and the `test/organization/test.sh`.

Particularly the fdw test count on the `publicuser` being present but then the organization tests count on just the opposite. It is hard to relate the cause with the effect (see the traces posted in the ticket) but believe me, this fixes (that instance of) the problem.

`publicuser` is meant to be a system requirement, so I guess we can get around this and other test races just by assuming it is there or creating it on demand, pretty much like in this PR. The `DROP ROLE` should be optional.
