### PR TITLE
Fix migration script generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # cartodb/Makefile
 
 EXTENSION = cartodb
-EXTVERSION = 0.18.3
+EXTVERSION = 0.18.4
 
 SED = sed
 
@@ -75,7 +75,9 @@ UPGRADABLE = \
   0.17.1 \
   0.18.0 \
   0.18.1 \
+  0.18.2 \
   0.18.3 \
+  0.18.4 \
   $(EXTVERSION)dev \
   $(EXTVERSION)next \
   $(END)


### PR DESCRIPTION
In the 0.18.3 release the script to migrate from 0.18.2 was missing.

This will generate a new version 0.18.4 that when installed will generate scripts to migrate from all old versions to it, so it will be possible to migrate existing users to 0.18.4 (but not to 0.18.3)