### PR TITLE
Sequence Rename to avoid Collision

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+0.22.0 (yyyy-mm-dd)
+* Fix: allow older ogr2ogr to work in -append mode (#319)
+
 0.21.0 (2018-02-15)
 * Add optional parameter to limit the number of cells in grid-generation functions #322
 * Fix: grant usage on cartodb_id sequence when sharing read write #323

--- a/scripts-available/CDB_CartodbfyTable.sql
+++ b/scripts-available/CDB_CartodbfyTable.sql
@@ -792,7 +792,6 @@ DECLARE
   relname TEXT;
   relschema TEXT;
   relseq TEXT;
-  relseqtmp TEXT;
 
   destoid REGCLASS;
   destname TEXT;
@@ -915,7 +914,7 @@ BEGIN
   -- Put the primary key sequence in the right schema
   -- If the new table is not moving, better ensure the sequence name
   -- is unique
-  destseq := cartodb._CDB_Unique_Identifier(NULL, destseq, destschema);
+  destseq := cartodb._CDB_Unique_Identifier(NULL, relname, '_' || const.pkey || '_seq', destschema);
   destseq := Format('%I.%I', destschema, destseq);
   PERFORM _CDB_SQL(Format('CREATE SEQUENCE %s', destseq), '_CDB_Rewrite_Table');
 


### PR DESCRIPTION
This doesn't really fix anything on our side, since the existing code already avoids sequence name collisions, but it addresses the issue in #318. This would just allow older versions of ogr2ogr to avoid the bug fixed in [7203](https://trac.osgeo.org/gdal/ticket/7203) where ogr2ogr fixates on having a serial sequence named `<relname>_cartodb_id_seq`. What exposed the error was

* running an `ogr2ogr` data upload (works)
* running it again (fails with errors about missing sequence)

It happens because after the first `ogr2ogr` upload, the table is cartodb'fyed, and the sequence name changes when cartodbfy does the copy step, so it ends up with a unique sequence name that is **not** the  `<relname>_cartodb_id_seq` form `ogr2ogr` expects when running in `-append` mode, which seems to be the default for a not-first upload.