### PR TITLE
 Fix incorrect timestamps in CDB_TableMetadata_Text

### DIFF
--- a/scripts-available/CDB_TableMetadata.sql
+++ b/scripts-available/CDB_TableMetadata.sql
@@ -7,7 +7,7 @@ CREATE TABLE IF NOT EXISTS
 
 CREATE OR REPLACE VIEW public.CDB_TableMetadata_Text AS
        SELECT FORMAT('%I.%I', n.nspname::text, c.relname::text) tabname, updated_at
-       FROM public.CDB_TableMetadata, pg_catalog.pg_class c
+       FROM public.CDB_TableMetadata m JOIN pg_catalog.pg_class c ON m.tabname::oid = c.oid
        LEFT JOIN pg_catalog.pg_namespace n ON c.relnamespace = n.oid;
 
 -- No one can see this

--- a/test/extension/test.sh
+++ b/test/extension/test.sh
@@ -513,7 +513,12 @@ END
     DATABASE=fdw_target sql postgres "SELECT cdb_tablemetadatatouch('test_fdw.foo'::regclass);"
     DATABASE=fdw_target sql postgres "SELECT cdb_tablemetadatatouch('test_fdw.foo2'::regclass);"
 
-    sql postgres "SELECT cartodb.CDB_Conf_SetConf('fdws', '{\"test_fdw\": {\"server\": {\"host\": \"localhost\", \"dbname\": \"fdw_target\"},
+    # Add PGPORT to conf if it is set
+    PORT_SPEC=""
+    if [[ "$PGPORT" != "" ]] ; then
+        PORT_SPEC=", \"port\": \"$PGPORT\""
+    fi
+    sql postgres "SELECT cartodb.CDB_Conf_SetConf('fdws', '{\"test_fdw\": {\"server\": {\"host\": \"localhost\", \"dbname\": \"fdw_target\" $PORT_SPEC },
                                            \"users\": {\"public\": {\"user\": \"fdw_user\", \"password\": \"foobarino\"}}}}')"
 
     sql postgres "SELECT cartodb._CDB_Setup_FDW('test_fdw')"


### PR DESCRIPTION
# Summary

This issue was first identified in https://github.com/CartoDB/cartodb-postgresql/issues/308.  This is the fix proposed by @jgoizueta along with some tests.

# Details

Instead of performing a proper join on tabname, CDB_TableMetadata_Text joins
cdb_tablemetadata against pg_catalog.pg_class (i.e. All postgres tables,
views, indices, etc.) and gives a record for every possible tabname and
updated_at combination.  This results in the latest updated timestamp being
chosen for any table in CDB_Get_Foreign_Updated_At, which leads to unnecessary
and incorrect cache invalidation.