### PR TITLE
Add limit to the grid-generating functions

### DIFF
--- a/test/CDB_HexagonTest.sql
+++ b/test/CDB_HexagonTest.sql
@@ -1,3 +1,6 @@
+set client_min_messages to error;
+\set VERBOSITY TERSE
+
 -- Check correctness of an hexagons grid
 --
 -- Cells must have no overlaps and have a number of

--- a/test/CDB_HexagonTest.sql
+++ b/test/CDB_HexagonTest.sql
@@ -45,3 +45,9 @@ WITH
  0.002 as radius ),
  grid AS ( SELECT CDB_HexagonGrid(env, radius) AS cell from params)
 SELECT '#160', count(cell) > 23000 from grid;
+
+-- Check small grids are generated...
+SELECT COUNT(*) FROM cartodb.CDB_HexagonGrid(ST_MakeEnvelope(0,0,1000,1000,3857), 10);
+
+-- But large grids produce an error
+SELECT COUNT(*) FROM cartodb.CDB_HexagonGrid(ST_MakeEnvelope(0,0,1000,1000,3857), 1);

--- a/test/CDB_HexagonTest_expect
+++ b/test/CDB_HexagonTest_expect
@@ -1,5 +1,5 @@
+SET
 9|63|count / npoints
 #160|t
 3886
 ERROR:  The requested grid is too big to be rendered
-CONTEXT:  PL/pgSQL function cdb_hexagongrid(geometry,double precision,geometry,integer) line 80 at RAISE

--- a/test/CDB_HexagonTest_expect
+++ b/test/CDB_HexagonTest_expect
@@ -1,2 +1,5 @@
 9|63|count / npoints
 #160|t
+3886
+ERROR:  The requested grid is too big to be rendered
+CONTEXT:  PL/pgSQL function cdb_hexagongrid(geometry,double precision,geometry,integer) line 80 at RAISE

--- a/test/CDB_RectangleTest.sql
+++ b/test/CDB_RectangleTest.sql
@@ -1,0 +1,5 @@
+-- Check small grids are generated...
+SELECT COUNT(*) FROM cartodb.CDB_RectangleGrid(ST_MakeEnvelope(0,0,1000,1000,3857), 10, 10);
+
+-- But large grids produce an error
+SELECT COUNT(*) FROM cartodb.CDB_RectangleGrid(ST_MakeEnvelope(0,0,1000,1000,3857), 1, 1);

--- a/test/CDB_RectangleTest.sql
+++ b/test/CDB_RectangleTest.sql
@@ -1,3 +1,6 @@
+set client_min_messages to error;
+\set VERBOSITY TERSE
+
 -- Check small grids are generated...
 SELECT COUNT(*) FROM cartodb.CDB_RectangleGrid(ST_MakeEnvelope(0,0,1000,1000,3857), 10, 10);
 

--- a/test/CDB_RectangleTest_expect
+++ b/test/CDB_RectangleTest_expect
@@ -1,3 +1,3 @@
+SET
 10000
 ERROR:  The requested grid is too big to be rendered
-CONTEXT:  PL/pgSQL function cdb_rectanglegrid(geometry,double precision,double precision,geometry,integer) line 64 at RAISE

--- a/test/CDB_RectangleTest_expect
+++ b/test/CDB_RectangleTest_expect
@@ -1,0 +1,3 @@
+10000
+ERROR:  The requested grid is too big to be rendered
+CONTEXT:  PL/pgSQL function cdb_rectanglegrid(geometry,double precision,double precision,geometry,integer) line 64 at RAISE


### PR DESCRIPTION
This adds an optinal maxcells parameter to the rectangle and hexagonal grids,
with a default value of 262144 (2^18).

An error occurs when the grids would need more cell