### PR TITLE
updates pg version based on cdb_quantiles update

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ See [the cartodb-postgresql wiki](https://github.com/CartoDB/cartodb-postgresql/
 Dependencies
 ------------
 
- * PostgreSQL 9.3+ (with plpythonu extension and xml support)
+ * PostgreSQL 9.4+ (with plpythonu extension and xml support)
  * [PostGIS extension](http://postgis.net) 
 
 Install


### PR DESCRIPTION
Updates the README to give correct minimum postgresql version that this extension is compatible with. This is due to the update to using `WITHIN GROUP` and `percentile_disc` in #316 

closes #328 

/cc @Algunenano 