### PR TITLE
Don't rely on regexp to identify non explainable queries

### DIFF
--- a/scripts-available/CDB_QueryTables.sql
+++ b/scripts-available/CDB_QueryTables.sql
@@ -11,19 +11,16 @@ DECLARE
   rec RECORD;
   rec2 RECORD;
 BEGIN
-  
+
   tables := '{}';
 
   FOR rec IN SELECT CDB_QueryStatements(query) q LOOP
-
-    IF NOT ( rec.q ilike 'select%' or rec.q ilike 'with%' ) THEN
-        --RAISE WARNING 'Skipping %', rec.q;
-        CONTINUE;
-    END IF;
-
     BEGIN
       EXECUTE 'EXPLAIN (FORMAT XML, VERBOSE) ' || rec.q INTO STRICT exp;
-    EXCEPTION WHEN others THEN
+    EXCEPTION WHEN syntax_error THEN
+      -- We can get a syntax error if the user tries to EXPLAIN a DDL
+      CONTINUE;
+    WHEN others THEN
       -- TODO: if error is 'relation "xxxxxx" does not exist', take xxxxxx as
       --       the affected table ?
       RAISE WARNING 'CDB_QueryTables cannot explain query: % (%: %)', rec.q, SQLSTATE, SQLERRM;

--- a/test/organization/test.sh
+++ b/test/organization/test.sh
@@ -426,6 +426,12 @@ function test_cdb_querytables_returns_schema_and_table_name() {
     sql cdb_testmember_1 "select * from CDB_QueryTables('select * from foo');" should "{cdb_testmember_1.foo}"
 }
 
+function test_cdb_querytables_works_with_parentheses() {
+    load_sql_file scripts-available/CDB_QueryStatements.sql
+    load_sql_file scripts-available/CDB_QueryTables.sql
+    sql cdb_testmember_1 "select * from CDB_QueryTables('(select * from foo)');" should "{cdb_testmember_1.foo}"
+}
+
 function test_cdb_querytables_returns_schema_and_table_name_for_several_schemas() {
     load_sql_file scripts-available/CDB_QueryStatements.sql
     load_sql_file scripts-available/CDB_QueryTables.sql


### PR DESCRIPTION
CartoDB/support#1669

The regexp was not correctly matching all SELECTs. For example, if it was prefixed by a parenthesis, the query could still eb valid, but the query tables code would ignore it.

This PRs relies in errors from the EXPLAIN instead.