### PR TITLE
Add explicit schema for Ghost Tables functions

### DIFF
--- a/scripts-available/CDB_GhostTables.sql
+++ b/scripts-available/CDB_GhostTables.sql
@@ -53,7 +53,7 @@ AS $$
     username TEXT;
     db_name TEXT;
   BEGIN
-    EXECUTE 'SELECT CDB_Username();' INTO username;
+    EXECUTE 'SELECT cartodb.CDB_Username();' INTO username;
     EXECUTE 'SELECT current_database();' INTO db_name;
 
     PERFORM cartodb._CDB_LinkGhostTables(username, db_name, event_name);

--- a/scripts-available/CDB_GhostTables.sql
+++ b/scripts-available/CDB_GhostTables.sql
@@ -68,8 +68,7 @@ AS $$
   DECLARE
     ddl_tag TEXT;
   BEGIN
-    EXECUTE 'SELECT tag FROM cartodb.cdb_ddl_execution WHERE txid = txid_current();' INTO ddl_tag;
-    DELETE FROM cartodb.cdb_ddl_execution WHERE txid = txid_current();
+    EXECUTE 'DELETE FROM cartodb.cdb_ddl_execution WHERE txid = txid_current() RETURNING tag;' INTO ddl_tag;
     PERFORM cartodb.CDB_LinkGhostTables(ddl_tag);
     RETURN NULL;
   END;

--- a/scripts-available/CDB_Username.sql
+++ b/scripts-available/CDB_Username.sql
@@ -1,6 +1,6 @@
 -- Returns the cartodb username of the current PostgreSQL session
-CREATE OR REPLACE FUNCTION CDB_Username()
+CREATE OR REPLACE FUNCTION cartodb.CDB_Username()
 RETURNS text
 AS $$
-  SELECT CDB_Conf_GetConf(CONCAT('api_keys_', session_user))->>'username';
+  SELECT cartodb.CDB_Conf_GetConf(CONCAT('api_keys_', session_user))->>'username';
 $$ LANGUAGE SQL STABLE PARALLEL SAFE SECURITY DEFINER;


### PR DESCRIPTION
It's safer to always use the cartodb schema for the functions. For example, some tests are failing in cartodb when installing this new trigger because it doesn't find the functions (because search_path is modified).