### PR TITLE
Remove default TIS config in Ghost Table function

### DIFF
--- a/scripts-available/CDB_GhostTables.sql
+++ b/scripts-available/CDB_GhostTables.sql
@@ -13,6 +13,7 @@ AS $$
 
   tis_config = plpy.execute("select cartodb.CDB_Conf_GetConf('invalidation_service');")[0]['cdb_conf_getconf']
   if not tis_config:
+    plpy.warning('Invalidation service configuration not found. Skipping Ghost Tables linking.')
     return
 
   tis_config_dict = json.loads(tis_config)

--- a/scripts-available/CDB_GhostTables.sql
+++ b/scripts-available/CDB_GhostTables.sql
@@ -12,9 +12,12 @@ AS $$
     json = GD['json']    
 
   tis_config = plpy.execute("select cartodb.CDB_Conf_GetConf('invalidation_service');")[0]['cdb_conf_getconf']
-  tis_config_dict = json.loads(tis_config) if tis_config else {}
-  tis_host = tis_config_dict.get('host', '127.0.0.1')
-  tis_port = tis_config_dict.get('port', 3142)
+  if not tis_config:
+    return
+
+  tis_config_dict = json.loads(tis_config)
+  tis_host = tis_config_dict.get('host')
+  tis_port = tis_config_dict.get('port')
   tis_timeout = tis_config_dict.get('timeout', 5)
   tis_retry = tis_config_dict.get('retry', 5)
       

--- a/scripts-available/CDB_GhostTables.sql
+++ b/scripts-available/CDB_GhostTables.sql
@@ -33,7 +33,7 @@ AS $$
         except Exception as err:
           error = "client_error - %s" % str(err)
           # NOTE: no retries on connection error
-          plpy.warning('Invalidation Service connection error: ' +  str(err))
+          plpy.warning('Error trying to connect to Invalidation Service to link Ghost Tables: ' +  str(err))
           break
 
     try:
@@ -43,7 +43,7 @@ AS $$
       error = "request_error - %s" % str(err)
       client = GD['invalidation'] = None # force reconnect
       if not tis_retry:
-        plpy.warning('Invalidation Service error: ' +  str(err))
+        plpy.warning('Error calling Invalidation Service to link Ghost Tables: ' +  str(err))
         break
       tis_retry -= 1 # try reconnecting
 $$ LANGUAGE 'plpythonu' VOLATILE PARALLEL UNSAFE;

--- a/test/CDB_GhostTables.sql
+++ b/test/CDB_GhostTables.sql
@@ -15,7 +15,7 @@ SET client_min_messages TO notice;
 
 SELECT CDB_LinkGhostTables(); -- _CDB_LinkGhostTables called, TIS connection not tried
 
--- Disable Ghost tables trigger
+-- Add TIS configuration
 \set QUIET on
 SET SESSION AUTHORIZATION postgres;
 SELECT cartodb.CDB_Conf_SetConf('invalidation_service', '{"host": "fake-tis-host", "port": 3142}');

--- a/test/CDB_GhostTables.sql
+++ b/test/CDB_GhostTables.sql
@@ -13,7 +13,7 @@ SET SESSION AUTHORIZATION "fulano";
 SET client_min_messages TO notice;
 \set QUIET off
 
-SELECT CDB_LinkGhostTables(); -- _CDB_LinkGhostTables called, TIS connection not tried
+SELECT CDB_LinkGhostTables(); -- _CDB_LinkGhostTables called (configuration not found)
 
 -- Add TIS configuration
 \set QUIET on

--- a/test/CDB_GhostTables.sql
+++ b/test/CDB_GhostTables.sql
@@ -7,10 +7,19 @@ GRANT ALL ON SCHEMA cartodb TO "fulano";
 GRANT SELECT ON cartodb.cdb_ddl_execution TO "fulano";
 GRANT EXECUTE ON FUNCTION CDB_Username() TO "fulano";
 GRANT EXECUTE ON FUNCTION CDB_LinkGhostTables(text) TO "fulano";
-INSERT INTO cdb_conf (key, value) VALUES ('api_keys_fulano', '{"username": "fulanito", "permissions":[]}');
-INSERT INTO cdb_conf (key, value) VALUES ('invalidation_service', '{"host": "fake-tis-host"}');
+SELECT cartodb.CDB_Conf_SetConf('api_keys_fulano', '{"username": "fulanito", "permissions":[]}');
+DELETE FROM cdb_conf WHERE key = 'invalidation_service';
 SET SESSION AUTHORIZATION "fulano";
 SET client_min_messages TO notice;
+\set QUIET off
+
+SELECT CDB_LinkGhostTables(); -- _CDB_LinkGhostTables called, TIS connection not tried
+
+-- Disable Ghost tables trigger
+\set QUIET on
+SET SESSION AUTHORIZATION postgres;
+SELECT cartodb.CDB_Conf_SetConf('invalidation_service', '{"host": "fake-tis-host", "port": 3142}');
+SET SESSION AUTHORIZATION "fulano";
 \set QUIET off
 
 SELECT CDB_LinkGhostTables(); -- _CDB_LinkGhostTables called

--- a/test/CDB_GhostTables_expect
+++ b/test/CDB_GhostTables_expect
@@ -1,4 +1,8 @@
 
+
+NOTICE:  _CDB_LinkGhostTables() called with username=fulanito, event_name=USER
+
+
 WARNING:  Invalidation Service error: Error -2 connecting fake-tis-host:3142. Name or service not known.
 NOTICE:  _CDB_LinkGhostTables() called with username=fulanito, event_name=USER
 

--- a/test/CDB_GhostTables_expect
+++ b/test/CDB_GhostTables_expect
@@ -1,4 +1,5 @@
 
+
 WARNING:  Invalidation service configuration not found. Skipping Ghost Tables linking.
 NOTICE:  _CDB_LinkGhostTables() called with username=fulanito, event_name=USER
 

--- a/test/CDB_GhostTables_expect
+++ b/test/CDB_GhostTables_expect
@@ -3,7 +3,7 @@
 NOTICE:  _CDB_LinkGhostTables() called with username=fulanito, event_name=USER
 
 
-WARNING:  Invalidation Service error: Error -2 connecting fake-tis-host:3142. Name or service not known.
+WARNING:  Error calling Invalidation Service to link Ghost Tables: Error -2 connecting fake-tis-host:3142. Name or service not known.
 NOTICE:  _CDB_LinkGhostTables() called with username=fulanito, event_name=USER
 
 BEGIN
@@ -11,7 +11,7 @@ cdb_ddl_execution
 0
 CREATE TABLE
 1
-WARNING:  Invalidation Service error: Error -2 connecting fake-tis-host:3142. Name or service not known.
+WARNING:  Error calling Invalidation Service to link Ghost Tables: Error -2 connecting fake-tis-host:3142. Name or service not known.
 NOTICE:  _CDB_LinkGhostTables() called with username=fulanito, event_name=CREATE TABLE
 COMMIT
 

--- a/test/CDB_GhostTables_expect
+++ b/test/CDB_GhostTables_expect
@@ -1,5 +1,5 @@
 
-
+WARNING:  Invalidation service configuration not found. Skipping Ghost Tables linking.
 NOTICE:  _CDB_LinkGhostTables() called with username=fulanito, event_name=USER
 
 


### PR DESCRIPTION
Remove default values for TIS connection to avoid failing attempts when it hasn't been configured.