### PR TITLE
COALESCE source columns

### DIFF
--- a/scripts-available/CDB_SyncTable.sql
+++ b/scripts-available/CDB_SyncTable.sql
@@ -46,7 +46,7 @@ DECLARE
 BEGIN
   FOREACH col IN ARRAY colnames
   LOOP
-    set_clause_list := array_append(set_clause_list, format('%1$s = %2$s.%1$s', col, update_source));
+    set_clause_list := array_append(set_clause_list, format('%1$s = COALESCE(%2$s.%1$s, %1$s)', col, update_source));
   END lOOP;
   RETURN array_to_string(set_clause_list, ', ');
 END;


### PR DESCRIPTION
What it does: it changes the generated UPDATE SET caluse so that
instead of

  the_geom = changed.the_geom

it will write

  the_geom = COALESCE(changed.the_geom, the_geom)

So, if the source column has a NULL value, it will keep whatever value
the target column has for that row.

This may be a general mechanism to work around syncing in a general
case. We may decide to apply it to specific columns instead but that
complicates the implementation (instead of skip_columns it may have
a harder-to-understand param "coalesce_columns", *if* they exist).

I'm creating this to discuss it. Note it greatly affects the simple
API.