### PR TITLE
Qualify all function calls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ env:
     - POSTGIS_VERSION="2.5"
 
   matrix:
-    - POSTGRESQL_VERSION="9.5"
     - POSTGRESQL_VERSION="10"
     - POSTGRESQL_VERSION="11"
 
@@ -20,7 +19,6 @@ before_install:
   - sudo service postgresql stop;
   - sudo apt-get remove postgresql* -y
   - sudo apt-get install -y --allow-unauthenticated --no-install-recommends --no-install-suggests postgresql-$POSTGRESQL_VERSION postgresql-client-$POSTGRESQL_VERSION postgresql-server-dev-$POSTGRESQL_VERSION postgresql-common
-  - if [[ $POSTGRESQL_VERSION == '9.5' ]]; then sudo apt-get install -y postgresql-contrib-9.5; fi;
   - sudo apt-get install -y --allow-unauthenticated postgresql-$POSTGRESQL_VERSION-postgis-$POSTGIS_VERSION postgresql-$POSTGRESQL_VERSION-postgis-$POSTGIS_VERSION-scripts postgis postgresql-plpython-$POSTGRESQL_VERSION
   - sudo pg_dropcluster --stop $POSTGRESQL_VERSION main
   - sudo rm -rf /etc/postgresql/$POSTGRESQL_VERSION /var/lib/postgresql/$POSTGRESQL_VERSION

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ env:
     - POSTGIS_VERSION="2.5"
 
   matrix:
+    - POSTGRESQL_VERSION="9.6"
     - POSTGRESQL_VERSION="10"
     - POSTGRESQL_VERSION="11"
 
@@ -19,6 +20,7 @@ before_install:
   - sudo service postgresql stop;
   - sudo apt-get remove postgresql* -y
   - sudo apt-get install -y --allow-unauthenticated --no-install-recommends --no-install-suggests postgresql-$POSTGRESQL_VERSION postgresql-client-$POSTGRESQL_VERSION postgresql-server-dev-$POSTGRESQL_VERSION postgresql-common
+  - if [[ $POSTGRESQL_VERSION == '9.6' ]]; then sudo apt-get install -y postgresql-contrib-9.6; fi;
   - sudo apt-get install -y --allow-unauthenticated postgresql-$POSTGRESQL_VERSION-postgis-$POSTGIS_VERSION postgresql-$POSTGRESQL_VERSION-postgis-$POSTGIS_VERSION-scripts postgis postgresql-plpython-$POSTGRESQL_VERSION
   - sudo pg_dropcluster --stop $POSTGRESQL_VERSION main
   - sudo rm -rf /etc/postgresql/$POSTGRESQL_VERSION /var/lib/postgresql/$POSTGRESQL_VERSION

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,14 +24,13 @@ version of objects in other cases.
 
 When adding a new function or modifying an exiting one make sure that the
 [VOLATILITY](https://www.postgresql.org/docs/current/static/xfunc-volatility.html) and [PARALLEL](https://www.postgresql.org/docs/9.6/static/parallel-safety.html) categories are updated accordingly.
-As PARALLEL labels need to be stripped for incompatible PostgreSQL versions
-please use _PARALLEL SAFE/RESTRICTED/UNSAFE_ in uppercase so it's handled
-automatically.
 
-When used as an extension (probably always from version 0.2.0 onwards)
-all the objects will be installed in a "cartodb" schema. Take this into
-account to fully-qualify internal calls to avoid (possibly dangerous)
-name clashes.
+
+Although the extension will usually be installed in the "cartodb" schema, please
+use @extschema@  to fully-qualify internal calls to avoid name clashes.
+When you use postgis functions or types, please fully-qualify them by using
+@postgisschema@ (it's changed to "public" by the install script) to avoid
+pg_upgrade issues.
 
 Every new feature (as well as bugfixes) should come with a test case,
 see the 'Writing testcases' section.

--- a/Makefile
+++ b/Makefile
@@ -123,24 +123,15 @@ REGRESS = test_setup $(REGRESS_LEGACY)
 
 PG_CONFIG = pg_config
 PGXS := $(shell $(PG_CONFIG) --pgxs)
-PG_PARALLEL := $(shell $(PG_CONFIG) --version | ($(AWK) '{$$2*=1000; if ($$2 >= 9600) print 1; else print 0;}' 2> /dev/null || echo 0))
 include $(PGXS)
 
 $(EXTENSION)--$(EXTVERSION).sql: $(CDBSCRIPTS) cartodb_version.sql Makefile
 	echo '\echo Use "CREATE EXTENSION $(EXTENSION)" to load this file. \quit' > $@
 	cat $(CDBSCRIPTS) | \
-	$(SED) -e 's/public\./cartodb./g' \
-		-e 's/:DATABASE_USERNAME/cdb_org_admin/g' \
-		-e "s/''public''/''cartodb''/g" >> $@
+	$(SED) 	-e 's/@extschema@/cartodb/g' \
+		-e "s/@postgisschema@/public/g" >> $@
 	echo "GRANT USAGE ON SCHEMA cartodb TO public;" >> $@
 	cat cartodb_version.sql >> $@
-ifeq ($(PG_PARALLEL), 0)
-# Remove PARALLEL in aggregates and functions
-	$(eval TMPFILE := $(shell mktemp /tmp/$(basename $0).XXXXXXXX))
-	$(SED) -e 's/PARALLEL \= [A-Z]*,/''/g' \
-		-e 's/PARALLEL [A-Z]*/''/g' $@ > $(TMPFILE)
-	mv $(TMPFILE) $@
-endif
 
 $(EXTENSION)--unpackaged--$(EXTVERSION).sql: $(EXTENSION)--$(EXTVERSION).sql util/create_from_unpackaged.sh Makefile
 	./util/create_from_unpackaged.sh $(EXTVERSION)
@@ -153,12 +144,9 @@ $(EXTENSION)--$(EXTVERSION)--$(EXTVERSION)next.sql: $(EXTENSION)--$(EXTVERSION).
 
 $(EXTENSION).control: $(EXTENSION).control.in Makefile
 	$(SED) -e 's/@@VERSION@@/$(EXTVERSION)/' $< > $@
-ifeq ($(PG_PARALLEL), 0)
-	echo -e "\033[0;31mExtension created without PARALLEL support\033[0m"
-endif
 
 cartodb_version.sql: cartodb_version.sql.in Makefile $(GITDIR)/index
-	$(SED) -e 's/@@VERSION@@/$(EXTVERSION)/' $< > $@
+	$(SED) -e 's/@@VERSION@@/$(EXTVERSION)/' -e 's/@extschema@/cartodb/g' -e "s/@postgisschema@/public/g" $< > $@
 
 # Needed for consistent `echo` results with backslashes
 SHELL = bash
@@ -175,7 +163,7 @@ legacy_regress: $(REGRESS_OLD) Makefile
 		echo '\t' >> $${of}; \
 		echo '\set QUIET off' >> $${of}; \
 		cat $${f} | \
-			$(SED) -e 's/public\./cartodb./g' >> $${of}; \
+			$(SED) -e 's/@@VERSION@@/$(EXTVERSION)/' -e 's/@extschema@/cartodb/g' -e "s/@postgisschema@/public/g" >> $${of}; \
 		exp=expected/test/$${tn}.out; \
 		echo '\set ECHO none' > $${exp}; \
 		cat test/$${tn}_expect >> $${exp}; \

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+0.27.0 (2019-05-31)
+* Fully qualify function calls
+* Several improvements to bash tests.
+* Avoid dropping publicuser in tests.
+* Raise minimum requirement to PostgreSQL 9.6.
+
 0.26.1 (2019-03-19)
 * Remove default TIS values from Ghost tables functions
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ See [the cartodb-postgresql wiki](https://github.com/CartoDB/cartodb-postgresql/
 Dependencies
 ------------
 
- * PostgreSQL 9.4+ (with plpythonu extension and xml support)
+ * PostgreSQL 9.6+ (with plpythonu extension and xml support)
  * [PostGIS extension](http://postgis.net)
  * Python with [Redis module](https://pypi.org/project/redis/)
 

--- a/carto-package.json
+++ b/carto-package.json
@@ -2,8 +2,8 @@
     "name": "carto_postgresql_ext",
     "current_version": {
         "requires": {
-            "postgresql": ">=9.5.0",
-            "postgis": ">=2.2.0.0"
+            "postgresql": ">=10.0",
+            "postgis": ">=2.4.0.0"
         },
         "works_with": {
         }

--- a/cartodb_version.sql.in
+++ b/cartodb_version.sql.in
@@ -1,6 +1,6 @@
 DO $$ BEGIN IF EXISTS (SELECT * FROM pg_proc p, pg_namespace n WHERE p.proname = 'cdb_transformtowebmercator' AND p.pronamespace = n.oid AND n.nspname = 'public') THEN RAISE EXCEPTION 'Use CREATE EXTENSION cartodb FROM unpackaged'; END IF; END; $$ LANGUAGE 'plpgsql'; -- forbid duplicated extension
 
-CREATE OR REPLACE FUNCTION cartodb.CDB_version()
+CREATE OR REPLACE FUNCTION @extschema@.CDB_version()
 RETURNS text AS $$
   SELECT '@@VERSION@@'::text;
 $$ language 'sql' IMMUTABLE STRICT;

--- a/scripts-available/CDB_AnalysisCatalog.sql
+++ b/scripts-available/CDB_AnalysisCatalog.sql
@@ -1,6 +1,6 @@
 -- Table to register analysis nodes from https://github.com/cartodb/camshaft
 CREATE TABLE IF NOT EXISTS
-cartodb.cdb_analysis_catalog (
+@extschema@.cdb_analysis_catalog (
     -- md5 hex hash
     node_id char(40) CONSTRAINT cdb_analysis_catalog_pkey PRIMARY KEY,
     -- being json allows to do queries like analysis_def->>'type' = 'buffer'
@@ -34,7 +34,7 @@ cartodb.cdb_analysis_catalog (
 -- This can only be called from an SQL script executed by CREATE EXTENSION
 DO LANGUAGE 'plpgsql' $$
 BEGIN
-    PERFORM pg_catalog.pg_extension_config_dump('cartodb.cdb_analysis_catalog', '');
+    PERFORM pg_catalog.pg_extension_config_dump('@extschema@.cdb_analysis_catalog', '');
 END
 $$;
 
@@ -45,7 +45,7 @@ $$;
 DO $$
     BEGIN
         BEGIN
-            ALTER TABLE cartodb.cdb_analysis_catalog ADD COLUMN last_modified_by uuid;
+            ALTER TABLE @extschema@.cdb_analysis_catalog ADD COLUMN last_modified_by uuid;
         EXCEPTION
             WHEN duplicate_column THEN END;
     END;
@@ -54,7 +54,7 @@ $$;
 DO $$
     BEGIN
         BEGIN
-            ALTER TABLE cartodb.cdb_analysis_catalog ADD COLUMN last_error_message text;
+            ALTER TABLE @extschema@.cdb_analysis_catalog ADD COLUMN last_error_message text;
         EXCEPTION
             WHEN duplicate_column THEN END;
     END;
@@ -63,7 +63,7 @@ $$;
 DO $$
     BEGIN
         BEGIN
-            ALTER TABLE cartodb.cdb_analysis_catalog ADD COLUMN cache_tables regclass[] NOT NULL DEFAULT '{}';
+            ALTER TABLE @extschema@.cdb_analysis_catalog ADD COLUMN cache_tables regclass[] NOT NULL DEFAULT '{}';
         EXCEPTION
             WHEN duplicate_column THEN END;
     END;
@@ -72,7 +72,7 @@ $$;
 DO $$
     BEGIN
         BEGIN
-            ALTER TABLE cartodb.cdb_analysis_catalog ADD COLUMN username text;
+            ALTER TABLE @extschema@.cdb_analysis_catalog ADD COLUMN username text;
         EXCEPTION
             WHEN duplicate_column THEN END;
     END;
@@ -84,12 +84,12 @@ DO LANGUAGE 'plpgsql' $$
     DECLARE
         column_index int;
     BEGIN
-        SELECT ordinal_position FROM information_schema.columns WHERE table_name='cdb_analysis_catalog' AND table_schema='cartodb' AND column_name='username' INTO column_index;
+        SELECT ordinal_position FROM information_schema.columns WHERE table_name='cdb_analysis_catalog' AND table_schema='@extschema@' AND column_name='username' INTO column_index;
         IF column_index = 1 OR column_index = 10 THEN
-           ALTER TABLE cartodb.cdb_analysis_catalog ADD COLUMN username_final text;
-           UPDATE cartodb.cdb_analysis_catalog SET username_final = username;
-           ALTER TABLE cartodb.cdb_analysis_catalog DROP COLUMN username;
-           ALTER TABLE cartodb.cdb_analysis_catalog RENAME COLUMN username_final TO username;
+           ALTER TABLE @extschema@.cdb_analysis_catalog ADD COLUMN username_final text;
+           UPDATE @extschema@.cdb_analysis_catalog SET username_final = username;
+           ALTER TABLE @extschema@.cdb_analysis_catalog DROP COLUMN username;
+           ALTER TABLE @extschema@.cdb_analysis_catalog RENAME COLUMN username_final TO username;
         END IF;
     END;
 $$;

--- a/scripts-available/CDB_AnalysisSupport.sql
+++ b/scripts-available/CDB_AnalysisSupport.sql
@@ -2,7 +2,7 @@
 
 -- This function returns TRUE if a given table name corresponds to a Camshaft cached analysis table
 -- Scope: private.
-CREATE OR REPLACE FUNCTION _CDB_IsAnalysisTableName(table_name TEXT)
+CREATE OR REPLACE FUNCTION @extschema@._CDB_IsAnalysisTableName(table_name TEXT)
 RETURNS BOOLEAN
 AS $$
   BEGIN
@@ -15,10 +15,10 @@ $$ LANGUAGE PLPGSQL IMMUTABLE PARALLEL SAFE;
 -- that may contain user tables are returned.
 -- For each table, the regclass, schema name and table name are returned.
 -- Scope: private.
-CREATE OR REPLACE FUNCTION _CDB_AnalysisTablesInSchema(schema_name text DEFAULT NULL)
+CREATE OR REPLACE FUNCTION @extschema@._CDB_AnalysisTablesInSchema(schema_name text DEFAULT NULL)
 RETURNS TABLE(table_regclass REGCLASS, schema_name TEXT, table_name TEXT)
 AS $$
-  SELECT * FROM _CDB_UserTablesInSchema(schema_name) WHERE _CDB_IsAnalysisTableName(table_name);
+  SELECT * FROM @extschema@._CDB_UserTablesInSchema(schema_name) WHERE @extschema@._CDB_IsAnalysisTableName(table_name);
 $$ LANGUAGE 'sql' STABLE PARALLEL SAFE;
 
 -- This function returns a relation user tables excluding analysis tables
@@ -26,24 +26,24 @@ $$ LANGUAGE 'sql' STABLE PARALLEL SAFE;
 -- that may contain user tables are returned.
 -- For each table, the regclass, schema name and table name are returned.
 -- Scope: private.
-CREATE OR REPLACE FUNCTION _CDB_NonAnalysisTablesInSchema(schema_name text DEFAULT NULL)
+CREATE OR REPLACE FUNCTION @extschema@._CDB_NonAnalysisTablesInSchema(schema_name text DEFAULT NULL)
 RETURNS TABLE(table_regclass REGCLASS, schema_name TEXT, table_name TEXT)
 AS $$
-  SELECT * FROM _CDB_UserTablesInSchema(schema_name) WHERE Not _CDB_IsAnalysisTableName(table_name);
+  SELECT * FROM @extschema@._CDB_UserTablesInSchema(schema_name) WHERE Not @extschema@._CDB_IsAnalysisTableName(table_name);
 $$ LANGUAGE 'sql' STABLE PARALLEL SAFE;
 
 -- Total spaced used up by Camshaft cached analysis tables in the given schema.
 -- Scope: private.
-CREATE OR REPLACE FUNCTION _CDB_AnalysisDataSize(schema_name TEXT DEFAULT NULL)
+CREATE OR REPLACE FUNCTION @extschema@._CDB_AnalysisDataSize(schema_name TEXT DEFAULT NULL)
 RETURNS bigint AS
 $$
 DECLARE
   total_size bigint;
 BEGIN
   WITH analysis_tables AS (
-    SELECT t.schema_name, t.table_name FROM _CDB_AnalysisTablesInSchema(schema_name) t
+    SELECT t.schema_name, t.table_name FROM @extschema@._CDB_AnalysisTablesInSchema(schema_name) t
   )
-  SELECT COALESCE(INT8(SUM(_CDB_total_relation_size(analysis_tables.schema_name, analysis_tables.table_name))))::int8
+  SELECT COALESCE(INT8(SUM(@extschema@._CDB_total_relation_size(analysis_tables.schema_name, analysis_tables.table_name))))::int8
     INTO total_size FROM analysis_tables;
   IF total_size IS NOT NULL THEN
     RETURN total_size;

--- a/scripts-available/CDB_ColumnNames.sql
+++ b/scripts-available/CDB_ColumnNames.sql
@@ -1,5 +1,5 @@
 -- Function returning the column names of a table
-CREATE OR REPLACE FUNCTION CDB_ColumnNames(REGCLASS)
+CREATE OR REPLACE FUNCTION @extschema@.CDB_ColumnNames(REGCLASS)
 RETURNS SETOF information_schema.sql_identifier
 AS $$
   SELECT
@@ -13,4 +13,4 @@ $$ LANGUAGE SQL STABLE PARALLEL SAFE;
 
 -- This is to migrate from pre-0.2.0 version
 -- See http://github.com/CartoDB/cartodb-postgresql/issues/36
-GRANT EXECUTE ON FUNCTION CDB_ColumnNames(REGCLASS) TO PUBLIC;
+GRANT EXECUTE ON FUNCTION @extschema@.CDB_ColumnNames(REGCLASS) TO PUBLIC;

--- a/scripts-available/CDB_ColumnType.sql
+++ b/scripts-available/CDB_ColumnType.sql
@@ -1,5 +1,5 @@
 -- Function returning the type of a column
-CREATE OR REPLACE FUNCTION CDB_ColumnType(REGCLASS, TEXT)
+CREATE OR REPLACE FUNCTION @extschema@.CDB_ColumnType(REGCLASS, TEXT)
 RETURNS information_schema.character_data
 AS $$
   SELECT
@@ -13,4 +13,4 @@ $$ LANGUAGE SQL STABLE PARALLEL SAFE;
 
 -- This is to migrate from pre-0.2.0 version
 -- See http://github.com/CartoDB/cartodb-postgresql/issues/36
-GRANT EXECUTE ON FUNCTION CDB_ColumnType(REGCLASS, TEXT) TO public;
+GRANT EXECUTE ON FUNCTION @extschema@.CDB_ColumnType(REGCLASS, TEXT) TO public;

--- a/scripts-available/CDB_Conf.sql
+++ b/scripts-available/CDB_Conf.sql
@@ -5,44 +5,44 @@
 -- Functions needing reading configuration should use SECURITY DEFINER.
 ----------------------------------
 
--- This will trigger NOTICE if cartodb.CDB_CONF already exists
+-- This will trigger NOTICE if @extschema@.CDB_CONF already exists
 DO LANGUAGE 'plpgsql' $$
 BEGIN
-    CREATE TABLE IF NOT EXISTS cartodb.CDB_CONF ( KEY TEXT PRIMARY KEY, VALUE JSON NOT NULL );
+    CREATE TABLE IF NOT EXISTS @extschema@.CDB_CONF ( KEY TEXT PRIMARY KEY, VALUE JSON NOT NULL );
 END
 $$;
 
 -- This can only be called from an SQL script executed by CREATE EXTENSION
 DO LANGUAGE 'plpgsql' $$
 BEGIN
-    PERFORM pg_catalog.pg_extension_config_dump('cartodb.CDB_CONF', '');
+    PERFORM pg_catalog.pg_extension_config_dump('@extschema@.CDB_CONF', '');
 END
 $$;
 
 CREATE OR REPLACE
-FUNCTION cartodb.CDB_Conf_SetConf(key text, value JSON)
+FUNCTION @extschema@.CDB_Conf_SetConf(key text, value JSON)
     RETURNS void AS $$
 BEGIN
-    PERFORM cartodb.CDB_Conf_RemoveConf(key);
-    EXECUTE 'INSERT INTO cartodb.CDB_CONF (KEY, VALUE) VALUES ($1, $2);' USING key, value;
+    PERFORM @extschema@.CDB_Conf_RemoveConf(key);
+    EXECUTE 'INSERT INTO @extschema@.CDB_CONF (KEY, VALUE) VALUES ($1, $2);' USING key, value;
 END
 $$ LANGUAGE PLPGSQL VOLATILE PARALLEL UNSAFE;
 
 CREATE OR REPLACE
-FUNCTION cartodb.CDB_Conf_RemoveConf(key text)
+FUNCTION @extschema@.CDB_Conf_RemoveConf(key text)
     RETURNS void AS $$
 BEGIN
-    EXECUTE 'DELETE FROM cartodb.CDB_CONF WHERE KEY = $1;' USING key;
+    EXECUTE 'DELETE FROM @extschema@.CDB_CONF WHERE KEY = $1;' USING key;
 END
 $$ LANGUAGE PLPGSQL VOLATILE PARALLEL UNSAFE;
 
 CREATE OR REPLACE
-FUNCTION cartodb.CDB_Conf_GetConf(key text)
+FUNCTION @extschema@.CDB_Conf_GetConf(key text)
     RETURNS JSON AS $$
 DECLARE
     value JSON;
 BEGIN
-    EXECUTE 'SELECT VALUE FROM cartodb.CDB_CONF WHERE KEY = $1;' INTO value USING key;
+    EXECUTE 'SELECT VALUE FROM @extschema@.CDB_CONF WHERE KEY = $1;' INTO value USING key;
     RETURN value;
 END
 $$ LANGUAGE PLPGSQL STABLE PARALLEL SAFE;

--- a/scripts-available/CDB_DDLTriggers.sql
+++ b/scripts-available/CDB_DDLTriggers.sql
@@ -3,12 +3,12 @@
 -- Introduced again to make sure that updates do not leave dangling functions
 --
 
-DROP FUNCTION IF EXISTS cartodb.cdb_handle_create_table();
-DROP FUNCTION IF EXISTS cartodb.cdb_handle_drop_table();
-DROP FUNCTION IF EXISTS cartodb.cdb_handle_alter_column();
-DROP FUNCTION IF EXISTS cartodb.cdb_handle_drop_column();
-DROP FUNCTION IF EXISTS cartodb.cdb_handle_add_column();
-DROP FUNCTION IF EXISTS cartodb.cdb_disable_ddl_hooks();
-DROP FUNCTION IF EXISTS cartodb.cdb_enable_ddl_hooks();
+DROP FUNCTION IF EXISTS @extschema@.cdb_handle_create_table();
+DROP FUNCTION IF EXISTS @extschema@.cdb_handle_drop_table();
+DROP FUNCTION IF EXISTS @extschema@.cdb_handle_alter_column();
+DROP FUNCTION IF EXISTS @extschema@.cdb_handle_drop_column();
+DROP FUNCTION IF EXISTS @extschema@.cdb_handle_add_column();
+DROP FUNCTION IF EXISTS @extschema@.cdb_disable_ddl_hooks();
+DROP FUNCTION IF EXISTS @extschema@.cdb_enable_ddl_hooks();
 
 

--- a/scripts-available/CDB_DateToNumber.sql
+++ b/scripts-available/CDB_DateToNumber.sql
@@ -1,6 +1,6 @@
 -- Convert timestamp to double precision
 --
-CREATE OR REPLACE FUNCTION CDB_DateToNumber(input timestamp)
+CREATE OR REPLACE FUNCTION @extschema@.CDB_DateToNumber(input timestamp)
 RETURNS double precision AS $$
 DECLARE output double precision;
 BEGIN
@@ -16,7 +16,7 @@ LANGUAGE 'plpgsql' IMMUTABLE STRICT PARALLEL UNSAFE;
 
 -- Convert timestamp with time zone to double precision
 --
-CREATE OR REPLACE FUNCTION CDB_DateToNumber(input timestamp with time zone)
+CREATE OR REPLACE FUNCTION @extschema@.CDB_DateToNumber(input timestamp with time zone)
 RETURNS double precision AS $$
 DECLARE output double precision;
 BEGIN

--- a/scripts-available/CDB_DigitSeparator.sql
+++ b/scripts-available/CDB_DigitSeparator.sql
@@ -1,5 +1,5 @@
 -- Find thousand and decimal digits separators
-CREATE OR REPLACE FUNCTION CDB_DigitSeparator (rel REGCLASS, fld TEXT, OUT t CHAR, OUT d CHAR)
+CREATE OR REPLACE FUNCTION @extschema@.CDB_DigitSeparator (rel REGCLASS, fld TEXT, OUT t CHAR, OUT d CHAR)
 as $$ 
 DECLARE
   sql TEXT;

--- a/scripts-available/CDB_DistType.sql
+++ b/scripts-available/CDB_DistType.sql
@@ -10,7 +10,7 @@
 --    1. width_bucket/histograms: http://tapoueh.org/blog/2014/02/21-PostgreSQL-histogram
 --    2. R implementation: https://github.com/cran/agrmt
 
-CREATE OR REPLACE FUNCTION CDB_DistType ( in_array NUMERIC[] ) RETURNS text as $$
+CREATE OR REPLACE FUNCTION @extschema@.CDB_DistType ( in_array NUMERIC[] ) RETURNS text as $$
 DECLARE
     element_count INT4;
     minv numeric;
@@ -60,7 +60,7 @@ BEGIN
             i := i + 1;
         END LOOP;
 
-        signature = _CDB_DistTypeClassify(ajus);
+        signature = @extschema@._CDB_DistTypeClassify(ajus);
     END IF;
 
     RETURN signature;
@@ -69,7 +69,7 @@ $$ language plpgsql IMMUTABLE STRICT PARALLEL SAFE;
 
 -- Classify data into AJUSFL
 
-CREATE OR REPLACE FUNCTION _CDB_DistTypeClassify ( in_array INT[] ) RETURNS text as $$
+CREATE OR REPLACE FUNCTION @extschema@._CDB_DistTypeClassify ( in_array INT[] ) RETURNS text as $$
 DECLARE
     element_count INT4;
     maxv numeric;

--- a/scripts-available/CDB_DistinctMeasure.sql
+++ b/scripts-available/CDB_DistinctMeasure.sql
@@ -5,7 +5,7 @@
 -- 
 -- 
 
-CREATE OR REPLACE FUNCTION CDB_DistinctMeasure ( in_array text[], threshold numeric DEFAULT null ) RETURNS numeric as $$
+CREATE OR REPLACE FUNCTION @extschema@.CDB_DistinctMeasure ( in_array text[], threshold numeric DEFAULT null ) RETURNS numeric as $$
 DECLARE
     element_count INT4;
     maxval numeric;

--- a/scripts-available/CDB_EqualIntervalBins.sql
+++ b/scripts-available/CDB_EqualIntervalBins.sql
@@ -11,7 +11,7 @@
 -- 
 --
 
-CREATE OR REPLACE FUNCTION CDB_EqualIntervalBins ( in_array anyarray, breaks INT ) RETURNS anyarray as $$
+CREATE OR REPLACE FUNCTION @extschema@.CDB_EqualIntervalBins ( in_array anyarray, breaks INT ) RETURNS anyarray as $$
 WITH stats AS (
   SELECT min(e), (max(e)-min(e))/breaks AS del
     FROM (SELECT unnest(in_array) e) AS p)
@@ -21,4 +21,4 @@ SELECT array_agg(bins)
       FROM stats) q;
 $$ LANGUAGE SQL IMMUTABLE PARALLEL SAFE;
 
-DROP FUNCTION IF EXISTS CDB_EqualIntervalBins( numeric[], integer);
+DROP FUNCTION IF EXISTS @extschema@.CDB_EqualIntervalBins( numeric[], integer);

--- a/scripts-available/CDB_EstimateRowCount.sql
+++ b/scripts-available/CDB_EstimateRowCount.sql
@@ -1,5 +1,5 @@
 -- Internal function to generate stats for a table if they don't exist
-CREATE OR REPLACE FUNCTION _CDB_GenerateStats(reloid REGCLASS)
+CREATE OR REPLACE FUNCTION @extschema@._CDB_GenerateStats(reloid REGCLASS)
 RETURNS VOID
 AS $$
 DECLARE
@@ -15,14 +15,14 @@ END
 $$ LANGUAGE 'plpgsql' VOLATILE STRICT PARALLEL UNSAFE SECURITY DEFINER;
 
 -- Return a row count estimate of the result of a query using statistics
-CREATE OR REPLACE FUNCTION CDB_EstimateRowCount(query text)
+CREATE OR REPLACE FUNCTION @extschema@.CDB_EstimateRowCount(query text)
 RETURNS Numeric
 AS $$
 DECLARE
   plan JSON;
 BEGIN
   -- Make sure statistics exist for all the tables of the query
-  PERFORM _CDB_GenerateStats(tabname) FROM  unnest(CDB_QueryTablesText(query)) AS tabname;
+  PERFORM @extschema@._CDB_GenerateStats(tabname) FROM  unnest(@extschema@.CDB_QueryTablesText(query)) AS tabname;
 
   -- Use the query planner to obtain an estimate of the number of result rows
   EXECUTE 'EXPLAIN (FORMAT JSON) ' || query INTO STRICT plan;

--- a/scripts-available/CDB_ExtensionPost.sql
+++ b/scripts-available/CDB_ExtensionPost.sql
@@ -1,2 +1,2 @@
-SELECT pg_catalog.pg_extension_config_dump('cartodb.cdb_tablemetadata','');
+SELECT pg_catalog.pg_extension_config_dump('@extschema@.cdb_tablemetadata','');
 

--- a/scripts-available/CDB_ExtensionUtils.sql
+++ b/scripts-available/CDB_ExtensionUtils.sql
@@ -1,10 +1,10 @@
-CREATE OR REPLACE FUNCTION cartodb.cdb_extension_reload() RETURNS void
+CREATE OR REPLACE FUNCTION @extschema@.cdb_extension_reload() RETURNS void
 AS $$
 DECLARE
   ver TEXT;
   sql TEXT;
 BEGIN
-  ver := split_part(cartodb.cdb_version(), ' ', 1);
+  ver := split_part(@extschema@.cdb_version(), ' ', 1);
   sql := 'ALTER EXTENSION cartodb UPDATE TO ''' || ver || 'next''';
   EXECUTE sql;
   sql := 'ALTER EXTENSION cartodb UPDATE TO ''' || ver || '''';
@@ -12,7 +12,7 @@ BEGIN
 END;
 $$ language 'plpgsql' VOLATILE PARALLEL UNSAFE;
 
-CREATE OR REPLACE FUNCTION cartodb.schema_exists(schema_name text)
+CREATE OR REPLACE FUNCTION @extschema@.schema_exists(schema_name text)
 RETURNS boolean AS
 $$
   SELECT EXISTS(SELECT 1 FROM pg_namespace WHERE nspname = schema_name::text);

--- a/scripts-available/CDB_GreatCircle.sql
+++ b/scripts-available/CDB_GreatCircle.sql
@@ -1,23 +1,23 @@
 -- Great circle point-to-point routes, based on:
 --   http://blog.cartodb.com/jets-and-datelines/
 --
-CREATE OR REPLACE FUNCTION CDB_GreatCircle(start_point geometry, end_point geometry, max_segment_length NUMERIC DEFAULT 100000)
-RETURNS geometry AS $$
+CREATE OR REPLACE FUNCTION @extschema@.CDB_GreatCircle(start_point @postgisschema@.geometry, end_point @postgisschema@.geometry, max_segment_length NUMERIC DEFAULT 100000)
+RETURNS @postgisschema@.geometry AS $$
 DECLARE
-  line geometry;
+  line @postgisschema@.geometry;
 BEGIN
-  line = ST_Segmentize(
-    ST_Makeline(
+  line = @postgisschema@.ST_Segmentize(
+    @postgisschema@.ST_Makeline(
       start_point,
       end_point
     )::geography,
     max_segment_length
   )::geometry;
 
-  IF ST_XMax(line) - ST_XMin(line) > 180 THEN
-    line = ST_Difference(
-      ST_ShiftLongitude(line),
-			ST_Buffer(ST_GeomFromText('LINESTRING(180 90, 180 -90)', 4326), 0.00001)
+  IF @postgisschema@.ST_XMax(line) - @postgisschema@.ST_XMin(line) > 180 THEN
+    line = @postgisschema@.ST_Difference(
+      @postgisschema@.ST_ShiftLongitude(line),
+			@postgisschema@.ST_Buffer(@postgisschema@.ST_GeomFromText('LINESTRING(180 90, 180 -90)', 4326), 0.00001)
 		);
   END IF;
 RETURN line;

--- a/scripts-available/CDB_Groups.sql
+++ b/scripts-available/CDB_Groups.sql
@@ -6,14 +6,14 @@
 
 -- Creates a new group
 CREATE OR REPLACE
-FUNCTION cartodb.CDB_Group_CreateGroup(group_name text)
+FUNCTION @extschema@.CDB_Group_CreateGroup(group_name text)
     RETURNS VOID AS $$
 DECLARE
     group_role TEXT;
 BEGIN
-    group_role := cartodb._CDB_Group_GroupRole(group_name);
+    group_role := @extschema@._CDB_Group_GroupRole(group_name);
     EXECUTE format('CREATE ROLE %I NOLOGIN;', group_role);
-    PERFORM cartodb._CDB_Group_CreateGroup_API(group_name, group_role);
+    PERFORM @extschema@._CDB_Group_CreateGroup_API(group_name, group_role);
 END
 $$ LANGUAGE PLPGSQL VOLATILE PARALLEL UNSAFE;
 
@@ -23,72 +23,72 @@ $$ LANGUAGE PLPGSQL VOLATILE PARALLEL UNSAFE;
 -- Not even the role creator can drop the role and the objects it owns.
 -- All group owned objects by the group are permissions.
 CREATE OR REPLACE
-FUNCTION cartodb.CDB_Group_DropGroup(group_name text)
+FUNCTION @extschema@.CDB_Group_DropGroup(group_name text)
     RETURNS VOID AS $$
 DECLARE
     group_role TEXT;
 BEGIN
-    group_role := cartodb._CDB_Group_GroupRole(group_name);
+    group_role := @extschema@._CDB_Group_GroupRole(group_name);
     EXECUTE format('DROP OWNED BY %I', group_role);
     EXECUTE format('DROP ROLE IF EXISTS %I', group_role);
-    PERFORM cartodb._CDB_Group_DropGroup_API(group_name);
+    PERFORM @extschema@._CDB_Group_DropGroup_API(group_name);
 END
 $$ LANGUAGE PLPGSQL VOLATILE PARALLEL UNSAFE;
 
 -- Renames a group
 CREATE OR REPLACE
-FUNCTION cartodb.CDB_Group_RenameGroup(old_group_name text, new_group_name text)
+FUNCTION @extschema@.CDB_Group_RenameGroup(old_group_name text, new_group_name text)
     RETURNS VOID AS $$
 DECLARE
     old_group_role TEXT;
     new_group_role TEXT;
 BEGIN
-    old_group_role = cartodb._CDB_Group_GroupRole(old_group_name);
-    new_group_role = cartodb._CDB_Group_GroupRole(new_group_name);
+    old_group_role = @extschema@._CDB_Group_GroupRole(old_group_name);
+    new_group_role = @extschema@._CDB_Group_GroupRole(new_group_name);
     EXECUTE format('ALTER ROLE %I RENAME TO %I', old_group_role, new_group_role);
-    PERFORM cartodb._CDB_Group_RenameGroup_API(old_group_name, new_group_name, new_group_role);
+    PERFORM @extschema@._CDB_Group_RenameGroup_API(old_group_name, new_group_name, new_group_role);
 END
 $$ LANGUAGE PLPGSQL VOLATILE PARALLEL UNSAFE;
 
 -- Adds users to a group
 CREATE OR REPLACE
-FUNCTION cartodb.CDB_Group_AddUsers(group_name text, usernames text[])
+FUNCTION @extschema@.CDB_Group_AddUsers(group_name text, usernames text[])
     RETURNS VOID AS $$
 DECLARE
     group_role TEXT;
     user_role TEXT;
     username TEXT;
 BEGIN
-    group_role := cartodb._CDB_Group_GroupRole(group_name);
+    group_role := @extschema@._CDB_Group_GroupRole(group_name);
     foreach username in array usernames
     loop
-      user_role := cartodb._CDB_User_RoleFromUsername(username);
+      user_role := @extschema@._CDB_User_RoleFromUsername(username);
       IF(group_role IS NULL OR user_role IS NULL)
       THEN
         RAISE EXCEPTION 'Group role (%) and user role (%) must be already existing', group_role, user_role;
       END IF;
       EXECUTE format('GRANT %I TO %I', group_role, user_role);
     end loop;
-    PERFORM cartodb._CDB_Group_AddUsers_API(group_name, usernames);
+    PERFORM @extschema@._CDB_Group_AddUsers_API(group_name, usernames);
 END
 $$ LANGUAGE PLPGSQL VOLATILE PARALLEL UNSAFE;
 
 -- Removes users from a group
 CREATE OR REPLACE
-FUNCTION cartodb.CDB_Group_RemoveUsers(group_name text, usernames text[])
+FUNCTION @extschema@.CDB_Group_RemoveUsers(group_name text, usernames text[])
     RETURNS VOID AS $$
 DECLARE
     group_role TEXT;
     user_role TEXT;
     username TEXT;
 BEGIN
-    group_role := cartodb._CDB_Group_GroupRole(group_name);
+    group_role := @extschema@._CDB_Group_GroupRole(group_name);
     foreach username in array usernames
     loop
-      user_role := cartodb._CDB_User_RoleFromUsername(username);
+      user_role := @extschema@._CDB_User_RoleFromUsername(username);
       EXECUTE format('REVOKE %I FROM %I', group_role, user_role);
     end loop;
-    PERFORM cartodb._CDB_Group_RemoveUsers_API(group_name, usernames);
+    PERFORM @extschema@._CDB_Group_RemoveUsers_API(group_name, usernames);
 END
 $$ LANGUAGE PLPGSQL VOLATILE PARALLEL UNSAFE;
 
@@ -100,67 +100,67 @@ $$ LANGUAGE PLPGSQL VOLATILE PARALLEL UNSAFE;
 
 -- Grants table read permission to a group
 CREATE OR REPLACE
-FUNCTION cartodb.CDB_Group_Table_GrantRead(group_name text, username text, table_name text)
+FUNCTION @extschema@.CDB_Group_Table_GrantRead(group_name text, username text, table_name text)
     RETURNS VOID AS $$
 DECLARE
     group_role TEXT;
 BEGIN
-    PERFORM cartodb._CDB_Group_Table_GrantRead(group_name, username, table_name, true);
+    PERFORM @extschema@._CDB_Group_Table_GrantRead(group_name, username, table_name, true);
 END
 $$ LANGUAGE PLPGSQL VOLATILE PARALLEL UNSAFE;
 
 CREATE OR REPLACE
-FUNCTION cartodb._CDB_Group_Table_GrantRead(group_name text, username text, table_name text, sync boolean)
+FUNCTION @extschema@._CDB_Group_Table_GrantRead(group_name text, username text, table_name text, sync boolean)
     RETURNS VOID AS $$
 DECLARE
     group_role TEXT;
 BEGIN
-    group_role := cartodb._CDB_Group_GroupRole(group_name);
+    group_role := @extschema@._CDB_Group_GroupRole(group_name);
     EXECUTE format('GRANT USAGE ON SCHEMA %I TO %I', username, group_role);
     EXECUTE format('GRANT SELECT ON TABLE %I.%I TO %I', username, table_name, group_role );
     IF(sync) THEN
-      PERFORM cartodb._CDB_Group_Table_GrantPermission_API(group_name, username, table_name, 'r');
+      PERFORM @extschema@._CDB_Group_Table_GrantPermission_API(group_name, username, table_name, 'r');
     END IF;
 END
 $$ LANGUAGE PLPGSQL VOLATILE PARALLEL UNSAFE;
 
 -- Grants table write permission to a group
 CREATE OR REPLACE
-FUNCTION cartodb.CDB_Group_Table_GrantReadWrite(group_name text, username text, table_name text)
+FUNCTION @extschema@.CDB_Group_Table_GrantReadWrite(group_name text, username text, table_name text)
     RETURNS VOID AS $$
 DECLARE
     group_role TEXT;
 BEGIN
-    PERFORM cartodb._CDB_Group_Table_GrantReadWrite(group_name, username, table_name, true);
+    PERFORM @extschema@._CDB_Group_Table_GrantReadWrite(group_name, username, table_name, true);
 END
 $$ LANGUAGE PLPGSQL VOLATILE PARALLEL UNSAFE;
 
 CREATE OR REPLACE
-FUNCTION cartodb._CDB_Group_Table_GrantReadWrite(group_name text, username text, table_name text, sync boolean)
+FUNCTION @extschema@._CDB_Group_Table_GrantReadWrite(group_name text, username text, table_name text, sync boolean)
     RETURNS VOID AS $$
 DECLARE
     group_role TEXT;
 BEGIN
-    group_role := cartodb._CDB_Group_GroupRole(group_name);
+    group_role := @extschema@._CDB_Group_GroupRole(group_name);
     EXECUTE format('GRANT USAGE ON SCHEMA %I TO %I', username, group_role);
     EXECUTE format('GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE %I.%I TO %I', username, table_name, group_role);
-    PERFORM cartodb._CDB_Group_TableSequences_Permission(group_name, username, table_name, true);
+    PERFORM @extschema@._CDB_Group_TableSequences_Permission(group_name, username, table_name, true);
     IF(sync) THEN
-      PERFORM cartodb._CDB_Group_Table_GrantPermission_API(group_name, username, table_name, 'w');
+      PERFORM @extschema@._CDB_Group_Table_GrantPermission_API(group_name, username, table_name, 'w');
     END IF;
 END
 $$ LANGUAGE PLPGSQL VOLATILE PARALLEL UNSAFE;
 
 -- Granting and revoking permissions on sequences
 CREATE OR REPLACE
-FUNCTION cartodb._CDB_Group_TableSequences_Permission(group_name text, username text, table_name text, do_grant bool)
+FUNCTION @extschema@._CDB_Group_TableSequences_Permission(group_name text, username text, table_name text, do_grant bool)
     RETURNS VOID AS $$
 DECLARE
     column_name TEXT;
     sequence_name TEXT;
     group_role TEXT;
 BEGIN
-    group_role := cartodb._CDB_Group_GroupRole(group_name);
+    group_role := @extschema@._CDB_Group_GroupRole(group_name);
     FOR column_name IN EXECUTE 'SELECT COLUMN_NAME FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_CATALOG = current_database() AND TABLE_SCHEMA = $1 AND TABLE_NAME = $2 AND COLUMN_DEFAULT LIKE ''nextval%''' USING username, table_name
     LOOP
         EXECUTE format('SELECT PG_GET_SERIAL_SEQUENCE(''%I.%I'', ''%I'')', username, table_name, column_name) INTO sequence_name;
@@ -179,26 +179,26 @@ $$ LANGUAGE PLPGSQL VOLATILE PARALLEL UNSAFE;
 
 -- Revokes all permissions on a table from a group
 CREATE OR REPLACE
-FUNCTION cartodb.CDB_Group_Table_RevokeAll(group_name text, username text, table_name text)
+FUNCTION @extschema@.CDB_Group_Table_RevokeAll(group_name text, username text, table_name text)
     RETURNS VOID AS $$
 DECLARE
     group_role TEXT;
 BEGIN
-    PERFORM cartodb._CDB_Group_Table_RevokeAll(group_name, username, table_name, true);
+    PERFORM @extschema@._CDB_Group_Table_RevokeAll(group_name, username, table_name, true);
 END
 $$ LANGUAGE PLPGSQL VOLATILE PARALLEL UNSAFE;
 
 CREATE OR REPLACE
-FUNCTION cartodb._CDB_Group_Table_RevokeAll(group_name text, username text, table_name text, sync boolean)
+FUNCTION @extschema@._CDB_Group_Table_RevokeAll(group_name text, username text, table_name text, sync boolean)
     RETURNS VOID AS $$
 DECLARE
     group_role TEXT;
 BEGIN
-    group_role := cartodb._CDB_Group_GroupRole(group_name);
+    group_role := @extschema@._CDB_Group_GroupRole(group_name);
     EXECUTE format('REVOKE ALL ON TABLE %I.%I FROM %I', username, table_name, group_role);
-    PERFORM cartodb._CDB_Group_TableSequences_Permission(group_name, username, table_name, false);
+    PERFORM @extschema@._CDB_Group_TableSequences_Permission(group_name, username, table_name, false);
     IF(sync) THEN
-      PERFORM cartodb._CDB_Group_Table_RevokeAllPermission_API(group_name, username, table_name);
+      PERFORM @extschema@._CDB_Group_Table_RevokeAllPermission_API(group_name, username, table_name);
     END IF;
 END
 $$ LANGUAGE PLPGSQL VOLATILE PARALLEL UNSAFE;
@@ -208,14 +208,14 @@ $$ LANGUAGE PLPGSQL VOLATILE PARALLEL UNSAFE;
 -----------------------
 -- Given a group name returns a role. group_name must be a valid PostgreSQL idenfifier. See http://www.postgresql.org/docs/9.2/static/sql-syntax-lexical.html#SQL-SYNTAX-IDENTIFIERS
 CREATE OR REPLACE
-FUNCTION cartodb._CDB_Group_GroupRole(group_name text)
+FUNCTION @extschema@._CDB_Group_GroupRole(group_name text)
     RETURNS TEXT AS $$
 DECLARE
     group_role TEXT;
     prefix TEXT;
     max_length constant INTEGER := 63;
 BEGIN
-    prefix = format('%s_g_', cartodb._CDB_Group_ShortDatabaseName());
+    prefix = format('%s_g_', @extschema@._CDB_Group_ShortDatabaseName());
     group_role := format('%s%s', prefix, group_name);
     IF LENGTH(group_role) > max_length
     THEN
@@ -227,7 +227,7 @@ $$ LANGUAGE PLPGSQL STABLE PARALLEL SAFE;
 
 -- Returns the first owner of the schema matching username. Organization user schemas must have one only owner.
 CREATE OR REPLACE
-FUNCTION cartodb._CDB_User_RoleFromUsername(username text)
+FUNCTION @extschema@._CDB_User_RoleFromUsername(username text)
     RETURNS TEXT AS $$
 DECLARE
     user_role TEXT;
@@ -241,7 +241,7 @@ $$ LANGUAGE PLPGSQL STABLE PARALLEL SAFE;
 
 -- Database names are too long, we need a shorter version for composing role names
 CREATE OR REPLACE
-FUNCTION cartodb._CDB_Group_ShortDatabaseName()
+FUNCTION @extschema@._CDB_Group_ShortDatabaseName()
     RETURNS TEXT AS $$
 DECLARE
     short_database_name TEXT;

--- a/scripts-available/CDB_Groups_API.sql
+++ b/scripts-available/CDB_Groups_API.sql
@@ -2,30 +2,30 @@
 -- GROUP METADATA API FUNCTIONS
 --
 -- Meant to be used by CDB_Group_* functions to sync data with the editor.
--- Requires configuration parameter. Example: SELECT cartodb.CDB_Conf_SetConf('groups_api', '{ "host": "127.0.0.1", "port": 3000, "timeout": 10, "username": "extension", "password": "elephant" }');
+-- Requires configuration parameter. Example: SELECT @extschema@.CDB_Conf_SetConf('groups_api', '{ "host": "127.0.0.1", "port": 3000, "timeout": 10, "username": "extension", "password": "elephant" }');
 ----------------------------------
 
 -- TODO: delete this development cleanup before final merge
-DROP FUNCTION IF EXISTS cartodb.CDB_Group_AddMember(group_name text, username text);
-DROP FUNCTION IF EXISTS cartodb.CDB_Group_RemoveMember(group_name text, username text);
-DROP FUNCTION IF EXISTS cartodb._CDB_Group_AddMember_API(group_name text, username text);
-DROP FUNCTION IF EXISTS cartodb._CDB_Group_RemoveMember_API(group_name text, username text);
+DROP FUNCTION IF EXISTS @extschema@.CDB_Group_AddMember(group_name text, username text);
+DROP FUNCTION IF EXISTS @extschema@.CDB_Group_RemoveMember(group_name text, username text);
+DROP FUNCTION IF EXISTS @extschema@._CDB_Group_AddMember_API(group_name text, username text);
+DROP FUNCTION IF EXISTS @extschema@._CDB_Group_RemoveMember_API(group_name text, username text);
 
 -- Sends the create group request
 CREATE OR REPLACE
-FUNCTION cartodb._CDB_Group_CreateGroup_API(group_name text, group_role text)
+FUNCTION @extschema@._CDB_Group_CreateGroup_API(group_name text, group_role text)
     RETURNS VOID AS
 $$
     import string
 
     url = '/api/v1/databases/{0}/groups'
     body = '{ "name": "%s", "database_role": "%s" }' % (group_name, group_role)
-    query = "select cartodb._CDB_Group_API_Request('POST', '%s', '%s', '{200, 409}') as response_status" % (url, body)
+    query = "select @extschema@._CDB_Group_API_Request('POST', '%s', '%s', '{200, 409}') as response_status" % (url, body)
     plpy.execute(query)
 $$ LANGUAGE 'plpythonu' VOLATILE PARALLEL UNSAFE SECURITY DEFINER;
 
 CREATE OR REPLACE
-FUNCTION cartodb._CDB_Group_DropGroup_API(group_name text)
+FUNCTION @extschema@._CDB_Group_DropGroup_API(group_name text)
     RETURNS VOID AS
 $$
     import string
@@ -33,12 +33,12 @@ $$
 
     url = '/api/v1/databases/{0}/groups/%s' % (urllib.pathname2url(group_name))
 
-    query = "select cartodb._CDB_Group_API_Request('DELETE', '%s', '', '{204, 404}') as response_status" % url
+    query = "select @extschema@._CDB_Group_API_Request('DELETE', '%s', '', '{204, 404}') as response_status" % url
     plpy.execute(query)
 $$ LANGUAGE 'plpythonu' VOLATILE PARALLEL UNSAFE SECURITY DEFINER;
 
 CREATE OR REPLACE
-FUNCTION cartodb._CDB_Group_RenameGroup_API(old_group_name text, new_group_name text, new_group_role text)
+FUNCTION @extschema@._CDB_Group_RenameGroup_API(old_group_name text, new_group_name text, new_group_role text)
     RETURNS VOID AS
 $$
     import string
@@ -46,12 +46,12 @@ $$
 
     url = '/api/v1/databases/{0}/groups/%s' % (urllib.pathname2url(old_group_name))
     body = '{ "name": "%s", "database_role": "%s" }' % (new_group_name, new_group_role)
-    query = "select cartodb._CDB_Group_API_Request('PUT', '%s', '%s', '{200, 409}') as response_status" % (url, body)
+    query = "select @extschema@._CDB_Group_API_Request('PUT', '%s', '%s', '{200, 409}') as response_status" % (url, body)
     plpy.execute(query)
 $$ LANGUAGE 'plpythonu' VOLATILE PARALLEL UNSAFE SECURITY DEFINER;
 
 CREATE OR REPLACE
-FUNCTION cartodb._CDB_Group_AddUsers_API(group_name text, usernames text[])
+FUNCTION @extschema@._CDB_Group_AddUsers_API(group_name text, usernames text[])
     RETURNS VOID AS
 $$
     import string
@@ -59,12 +59,12 @@ $$
 
     url = '/api/v1/databases/{0}/groups/%s/users' % (urllib.pathname2url(group_name))
     body = "{ \"users\": [\"%s\"] }" % "\",\"".join(usernames)
-    query = "select cartodb._CDB_Group_API_Request('POST', '%s', '%s', '{200, 409}') as response_status" % (url, body)
+    query = "select @extschema@._CDB_Group_API_Request('POST', '%s', '%s', '{200, 409}') as response_status" % (url, body)
     plpy.execute(query)
 $$ LANGUAGE 'plpythonu' VOLATILE SECURITY DEFINER;
 
 CREATE OR REPLACE
-FUNCTION cartodb._CDB_Group_RemoveUsers_API(group_name text, usernames text[])
+FUNCTION @extschema@._CDB_Group_RemoveUsers_API(group_name text, usernames text[])
     RETURNS VOID AS
 $$
     import string
@@ -72,20 +72,20 @@ $$
 
     url = '/api/v1/databases/{0}/groups/%s/users' % (urllib.pathname2url(group_name))
     body = "{ \"users\": [\"%s\"] }" % "\",\"".join(usernames)
-    query = "select cartodb._CDB_Group_API_Request('DELETE', '%s', '%s', '{200, 404}') as response_status" % (url, body)
+    query = "select @extschema@._CDB_Group_API_Request('DELETE', '%s', '%s', '{200, 404}') as response_status" % (url, body)
     plpy.execute(query)
 $$ LANGUAGE 'plpythonu' VOLATILE PARALLEL UNSAFE SECURITY DEFINER;
 
 DO LANGUAGE 'plpgsql' $$
 BEGIN
     -- Needed for dropping type
-    DROP FUNCTION IF EXISTS cartodb._CDB_Group_API_Conf();
-    DROP TYPE IF EXISTS _CDB_Group_API_Params;
+    DROP FUNCTION IF EXISTS @extschema@._CDB_Group_API_Conf();
+    DROP TYPE IF EXISTS @extschema@._CDB_Group_API_Params;
 END
 $$;
 
 CREATE OR REPLACE
-FUNCTION cartodb._CDB_Group_Table_GrantPermission_API(group_name text, username text, table_name text, access text)
+FUNCTION @extschema@._CDB_Group_Table_GrantPermission_API(group_name text, username text, table_name text, access text)
     RETURNS VOID AS
 $$
     import string
@@ -93,39 +93,39 @@ $$
 
     url = '/api/v1/databases/{0}/groups/%s/permission/%s/tables/%s' % (urllib.pathname2url(group_name), username, table_name)
     body = '{ "access": "%s" }' % access
-    query = "select cartodb._CDB_Group_API_Request('PUT', '%s', '%s', '{200, 409}') as response_status" % (url, body)
+    query = "select @extschema@._CDB_Group_API_Request('PUT', '%s', '%s', '{200, 409}') as response_status" % (url, body)
     plpy.execute(query)
 $$ LANGUAGE 'plpythonu' VOLATILE PARALLEL UNSAFE SECURITY DEFINER;
 
 DO LANGUAGE 'plpgsql' $$
 BEGIN
     -- Needed for dropping type
-    DROP FUNCTION IF EXISTS cartodb._CDB_Group_API_Conf();
-    DROP TYPE IF EXISTS _CDB_Group_API_Params;
+    DROP FUNCTION IF EXISTS @extschema@._CDB_Group_API_Conf();
+    DROP TYPE IF EXISTS @extschema@._CDB_Group_API_Params;
 END
 $$;
 
 CREATE OR REPLACE
-FUNCTION cartodb._CDB_Group_Table_RevokeAllPermission_API(group_name text, username text, table_name text)
+FUNCTION @extschema@._CDB_Group_Table_RevokeAllPermission_API(group_name text, username text, table_name text)
     RETURNS VOID AS
 $$
     import string
     import urllib
 
     url = '/api/v1/databases/{0}/groups/%s/permission/%s/tables/%s' % (urllib.pathname2url(group_name), username, table_name)
-    query = "select cartodb._CDB_Group_API_Request('DELETE', '%s', '', '{200, 404}') as response_status" % url
+    query = "select @extschema@._CDB_Group_API_Request('DELETE', '%s', '', '{200, 404}') as response_status" % url
     plpy.execute(query)
 $$ LANGUAGE 'plpythonu' VOLATILE PARALLEL UNSAFE SECURITY DEFINER;
 
 DO LANGUAGE 'plpgsql' $$
 BEGIN
     -- Needed for dropping type
-    DROP FUNCTION IF EXISTS cartodb._CDB_Group_API_Conf();
-    DROP TYPE IF EXISTS _CDB_Group_API_Params;
+    DROP FUNCTION IF EXISTS @extschema@._CDB_Group_API_Conf();
+    DROP TYPE IF EXISTS @extschema@._CDB_Group_API_Params;
 END
 $$;
 
-CREATE TYPE _CDB_Group_API_Params AS (
+CREATE TYPE @extschema@._CDB_Group_API_Params AS (
     host text,
     port int,
     timeout int,
@@ -135,21 +135,21 @@ CREATE TYPE _CDB_Group_API_Params AS (
 -- This must be explicitally extracted because "composite types are currently not supported".
 -- See http://www.postgresql.org/docs/9.3/static/plpython-database.html.
 CREATE OR REPLACE
-FUNCTION cartodb._CDB_Group_API_Conf()
-    RETURNS _CDB_Group_API_Params AS
+FUNCTION @extschema@._CDB_Group_API_Conf()
+    RETURNS @extschema@._CDB_Group_API_Params AS
 $$
-    conf = plpy.execute("SELECT cartodb.CDB_Conf_GetConf('groups_api') conf")[0]['conf']
+    conf = plpy.execute("SELECT @extschema@.CDB_Conf_GetConf('groups_api') conf")[0]['conf']
     if conf is None:
       return None
     else:
       import json
       params = json.loads(conf)
-      auth = 'Basic %s' % plpy.execute("SELECT cartodb._CDB_Group_API_Auth('%s', '%s') as auth" % (params['username'], params['password']))[0]['auth']
+      auth = 'Basic %s' % plpy.execute("SELECT @extschema@._CDB_Group_API_Auth('%s', '%s') as auth" % (params['username'], params['password']))[0]['auth']
       return { "host": params['host'], "port": params['port'], 'timeout': params['timeout'], 'auth': auth }
 $$ LANGUAGE 'plpythonu' VOLATILE PARALLEL UNSAFE;
 
 CREATE OR REPLACE
-FUNCTION cartodb._CDB_Group_API_Auth(username text, password text)
+FUNCTION @extschema@._CDB_Group_API_Auth(username text, password text)
     RETURNS TEXT AS
 $$
     import base64
@@ -158,12 +158,12 @@ $$ LANGUAGE 'plpythonu' VOLATILE PARALLEL UNSAFE;
 
 -- url must contain a '%s' placeholder that will be replaced by current_database, for security reasons.
 CREATE OR REPLACE
-FUNCTION cartodb._CDB_Group_API_Request(method text, url text, body text, valid_return_codes int[])
+FUNCTION @extschema@._CDB_Group_API_Request(method text, url text, body text, valid_return_codes int[])
     RETURNS int AS
 $$
     import httplib
 
-    params = plpy.execute("select c.host, c.port, c.timeout, c.auth from cartodb._CDB_Group_API_Conf() c;")[0]
+    params = plpy.execute("select c.host, c.port, c.timeout, c.auth from @extschema@._CDB_Group_API_Conf() c;")[0]
     if params['host'] is None:
       return None
 
@@ -192,4 +192,4 @@ $$
 
     return None
 $$ LANGUAGE 'plpythonu' VOLATILE PARALLEL UNSAFE;
-revoke all on function cartodb._CDB_Group_API_Request(text, text, text, int[]) from public;
+revoke all on function @extschema@._CDB_Group_API_Request(text, text, text, int[]) from public;

--- a/scripts-available/CDB_HeadsTailsBins.sql
+++ b/scripts-available/CDB_HeadsTailsBins.sql
@@ -8,7 +8,7 @@
 --  
 --
 
-CREATE OR REPLACE FUNCTION CDB_HeadsTailsBins ( in_array NUMERIC[], breaks INT) RETURNS NUMERIC[] as $$ 
+CREATE OR REPLACE FUNCTION @extschema@.CDB_HeadsTailsBins ( in_array NUMERIC[], breaks INT) RETURNS NUMERIC[] as $$ 
 DECLARE 
     element_count INT4; 
     arr_mean numeric; 

--- a/scripts-available/CDB_Helper.sql
+++ b/scripts-available/CDB_Helper.sql
@@ -5,7 +5,7 @@
 -- UTF8 safe and length aware. Find a unique identifier with a given prefix
 -- and/or suffix and withing a schema. If a schema is not specified, the identifier
 -- is guaranteed to be unique for all schemas.
-CREATE OR REPLACE FUNCTION cartodb._CDB_Unique_Identifier(prefix TEXT, relname TEXT, suffix TEXT, schema TEXT DEFAULT NULL)
+CREATE OR REPLACE FUNCTION @extschema@._CDB_Unique_Identifier(prefix TEXT, relname TEXT, suffix TEXT, schema TEXT DEFAULT NULL)
 RETURNS TEXT
 AS $$
 DECLARE
@@ -24,10 +24,10 @@ BEGIN
   usedspace := usedspace + coalesce(octet_length(prefix), 0);
   usedspace := usedspace + coalesce(octet_length(suffix), 0);
 
-  candrelname := _CDB_Octet_Truncate(relname, maxlen - usedspace);
+  candrelname := @extschema@._CDB_Octet_Truncate(relname, maxlen - usedspace);
 
   IF candrelname = '' THEN
-    PERFORM _CDB_Error('prefixes are to long to generate a valid identifier', '_CDB_Unique_Identifier');
+    PERFORM @extschema@._CDB_Error('prefixes are to long to generate a valid identifier', '_CDB_Unique_Identifier');
   END IF;
 
   ident := coalesce(prefix, '') || candrelname || coalesce(suffix, '');
@@ -59,14 +59,14 @@ BEGIN
     i := i + 1;
   END LOOP;
 
-  PERFORM _CDB_Error('looping too far', '_CDB_Unique_Identifier');
+  PERFORM @extschema@._CDB_Error('looping too far', '_CDB_Unique_Identifier');
 END;
 $$ LANGUAGE 'plpgsql' VOLATILE PARALLEL UNSAFE;
 
 
 -- UTF8 safe and length aware. Find a unique identifier for a column with a given prefix
 -- and/or suffix based on colname and within a relation specified via reloid.
-CREATE OR REPLACE FUNCTION cartodb._CDB_Unique_Column_Identifier(prefix TEXT, colname TEXT, suffix TEXT, reloid REGCLASS)
+CREATE OR REPLACE FUNCTION @extschema@._CDB_Unique_Column_Identifier(prefix TEXT, colname TEXT, suffix TEXT, reloid REGCLASS)
 RETURNS TEXT
 AS $$
 DECLARE
@@ -85,10 +85,10 @@ BEGIN
   usedspace := usedspace + coalesce(octet_length(prefix), 0);
   usedspace := usedspace + coalesce(octet_length(suffix), 0);
 
-  candcolname := _CDB_Octet_Truncate(colname, maxlen - usedspace);
+  candcolname := @extschema@._CDB_Octet_Truncate(colname, maxlen - usedspace);
 
   IF candcolname = '' THEN
-    PERFORM _CDB_Error('prefixes are to long to generate a valid identifier', '_CDB_Unique_Column_Identifier');
+    PERFORM @extschema@._CDB_Error('prefixes are to long to generate a valid identifier', '_CDB_Unique_Column_Identifier');
   END IF;
 
   ident := coalesce(prefix, '') || candcolname || coalesce(suffix, '');
@@ -114,14 +114,14 @@ BEGIN
     i := i + 1;
   END LOOP;
 
-  PERFORM _CDB_Error('looping too far', '_CDB_Unique_Column_Identifier');
+  PERFORM @extschema@._CDB_Error('looping too far', '_CDB_Unique_Column_Identifier');
 END;
 $$ LANGUAGE 'plpgsql' VOLATILE PARALLEL SAFE;
 
 
 -- Truncates a given string to a max_octets octets taking care
 -- not to leave characters in half. UTF8 safe.
-CREATE OR REPLACE FUNCTION cartodb._CDB_Octet_Truncate(string TEXT, max_octets INTEGER)
+CREATE OR REPLACE FUNCTION @extschema@._CDB_Octet_Truncate(string TEXT, max_octets INTEGER)
 RETURNS TEXT
 AS $$
 DECLARE
@@ -162,7 +162,7 @@ $$ LANGUAGE 'plpgsql' IMMUTABLE PARALLEL SAFE;
 
 -- Checks if a given text representing a qualified or unqualified table name (relation)
 -- actually exists in the database. It is meant to be used as a guard for other function/queries.
-CREATE OR REPLACE FUNCTION cartodb._CDB_Table_Exists(table_name_with_optional_schema TEXT)
+CREATE OR REPLACE FUNCTION @extschema@._CDB_Table_Exists(table_name_with_optional_schema TEXT)
 RETURNS bool
 AS $$
 DECLARE

--- a/scripts-available/CDB_JenksBins.sql
+++ b/scripts-available/CDB_JenksBins.sql
@@ -13,7 +13,7 @@
 --
 --
 
-CREATE OR REPLACE FUNCTION CDB_JenksBins(in_array NUMERIC[], breaks INT, iterations INT DEFAULT 0, invert BOOLEAN DEFAULT FALSE)
+CREATE OR REPLACE FUNCTION @extschema@.CDB_JenksBins(in_array NUMERIC[], breaks INT, iterations INT DEFAULT 0, invert BOOLEAN DEFAULT FALSE)
 RETURNS NUMERIC[] as
 $$
 DECLARE
@@ -95,7 +95,7 @@ BEGIN
         IF i > breaks THEN EXIT; END IF;
     END LOOP;
 
-    best_result = CDB_JenksBinsIteration(in_matrix, breaks, classes, invert, sdam, shuffles);
+    best_result = @extschema@.CDB_JenksBinsIteration(in_matrix, breaks, classes, invert, sdam, shuffles);
 
     --set the seed so we can ensure the same results
     SELECT setseed(0.4567) INTO seedtarget;
@@ -126,7 +126,7 @@ BEGIN
             IF i > breaks THEN EXIT; END IF;
         END LOOP;
 
-        curr_result = CDB_JenksBinsIteration(in_matrix, breaks, classes, invert, sdam, shuffles);
+        curr_result = @extschema@.CDB_JenksBinsIteration(in_matrix, breaks, classes, invert, sdam, shuffles);
 
         IF curr_result[1] > best_result[1] THEN
             best_result = curr_result;
@@ -146,9 +146,9 @@ $$ LANGUAGE PLPGSQL IMMUTABLE PARALLEL RESTRICTED;
 -- Returns an array with:
 -- - First element: gvf
 -- - Second to 2+n: Category limits
-DROP FUNCTION IF EXISTS CDB_JenksBinsIteration ( in_matrix NUMERIC[], breaks INT, classes INT[], invert BOOLEAN, element_count INT4, arr_mean NUMERIC, max_search INT); -- Old signature
+DROP FUNCTION IF EXISTS @extschema@.CDB_JenksBinsIteration ( in_matrix NUMERIC[], breaks INT, classes INT[], invert BOOLEAN, element_count INT4, arr_mean NUMERIC, max_search INT); -- Old signature
 
-CREATE OR REPLACE FUNCTION CDB_JenksBinsIteration ( in_matrix NUMERIC[], breaks INT, classes INT[], invert BOOLEAN, sdam NUMERIC, max_search INT DEFAULT 50) RETURNS NUMERIC[] as $$
+CREATE OR REPLACE FUNCTION @extschema@.CDB_JenksBinsIteration ( in_matrix NUMERIC[], breaks INT, classes INT[], invert BOOLEAN, sdam NUMERIC, max_search INT DEFAULT 50) RETURNS NUMERIC[] as $$
 DECLARE
     i INT;
     iterations INT = 0;

--- a/scripts-available/CDB_LatLng.sql
+++ b/scripts-available/CDB_LatLng.sql
@@ -7,13 +7,11 @@
 --  
 --
 
-CREATE OR REPLACE FUNCTION CDB_LatLng (lat NUMERIC, lng NUMERIC) RETURNS geometry as $$ 
-    -- this function is silly
-    SELECT ST_SetSRID(ST_MakePoint(lng,lat),4326);
+CREATE OR REPLACE FUNCTION @extschema@.CDB_LatLng (lat NUMERIC, lng NUMERIC) RETURNS @postgisschema@.geometry as $$ 
+    SELECT @postgisschema@.ST_SetSRID(@postgisschema@.ST_MakePoint(lng,lat), 4326);
 $$ language SQL IMMUTABLE PARALLEL SAFE;
 
-CREATE OR REPLACE FUNCTION CDB_LatLng (lat FLOAT8, lng FLOAT8) RETURNS geometry as $$ 
-    -- this function is silly
-    SELECT ST_SetSRID(ST_MakePoint(lng,lat),4326);
+CREATE OR REPLACE FUNCTION @extschema@.CDB_LatLng (lat FLOAT8, lng FLOAT8) RETURNS @postgisschema@.geometry as $$
+    SELECT @postgisschema@.ST_SetSRID(@postgisschema@.ST_MakePoint(lng,lat), 4326);
 $$ language SQL IMMUTABLE PARALLEL SAFE;
 

--- a/scripts-available/CDB_Math.sql
+++ b/scripts-available/CDB_Math.sql
@@ -4,7 +4,7 @@
 -- Mode
 -- https://wiki.postgresql.org/wiki/Aggregate_Mode
 
-CREATE OR REPLACE FUNCTION cartodb._CDB_Math_final_mode(anyarray)
+CREATE OR REPLACE FUNCTION @extschema@._CDB_Math_final_mode(anyarray)
   RETURNS anyelement AS
 $BODY$
     SELECT a
@@ -15,12 +15,12 @@ $BODY$
 $BODY$
 LANGUAGE 'sql' IMMUTABLE PARALLEL SAFE;
 
-DROP AGGREGATE IF EXISTS cartodb.CDB_Math_Mode(anyelement);
+DROP AGGREGATE IF EXISTS @extschema@.CDB_Math_Mode(anyelement);
 
-CREATE AGGREGATE cartodb.CDB_Math_Mode(anyelement) (
+CREATE AGGREGATE @extschema@.CDB_Math_Mode(anyelement) (
   SFUNC=array_append,
   STYPE=anyarray,
-  FINALFUNC=_CDB_Math_final_mode,
+  FINALFUNC=@extschema@._CDB_Math_final_mode,
   PARALLEL = SAFE,
   INITCOND='{}'
 );

--- a/scripts-available/CDB_QuantileBins.sql
+++ b/scripts-available/CDB_QuantileBins.sql
@@ -7,7 +7,7 @@
 -- @param breaks The number of bins you want to find.
 --
 --
-CREATE OR REPLACE FUNCTION CDB_QuantileBins(in_array numeric[], breaks int)
+CREATE OR REPLACE FUNCTION @extschema@.CDB_QuantileBins(in_array numeric[], breaks int)
 RETURNS numeric[]
 AS $$
   SELECT

--- a/scripts-available/CDB_QueryStatements.sql
+++ b/scripts-available/CDB_QueryStatements.sql
@@ -3,7 +3,7 @@
 -- Regexp curtesy of Hubert Lubaczewski (depesz)
 -- Implemented in plpython for performance reasons
 --
-CREATE OR REPLACE FUNCTION CDB_QueryStatements(query text) 
+CREATE OR REPLACE FUNCTION @extschema@.CDB_QueryStatements(query text) 
 RETURNS SETOF TEXT AS $$
   import re
   pat = re.compile( r'''((?:[^'"$;]+|"[^"]*"|'[^']*'|(\$[^$]*\$).*?\2)+)''', re.DOTALL )

--- a/scripts-available/CDB_QueryTables.sql
+++ b/scripts-available/CDB_QueryTables.sql
@@ -2,7 +2,7 @@
 --
 -- Requires PostgreSQL 9.x+
 --
-CREATE OR REPLACE FUNCTION CDB_QueryTablesText(query text)
+CREATE OR REPLACE FUNCTION @extschema@.CDB_QueryTablesText(query text)
 RETURNS text[]
 AS $$
 DECLARE
@@ -14,7 +14,7 @@ BEGIN
 
   tables := '{}';
 
-  FOR rec IN SELECT CDB_QueryStatements(query) q LOOP
+  FOR rec IN SELECT @extschema@.CDB_QueryStatements(query) q LOOP
     BEGIN
       EXECUTE 'EXPLAIN (FORMAT XML, VERBOSE) ' || rec.q INTO STRICT exp;
     EXCEPTION WHEN syntax_error THEN
@@ -66,10 +66,10 @@ $$ LANGUAGE 'plpgsql' VOLATILE STRICT PARALLEL UNSAFE;
 
 -- Keep CDB_QueryTables with same signature for backwards compatibility.
 -- It should probably be removed in the future.
-CREATE OR REPLACE FUNCTION CDB_QueryTables(query text)
+CREATE OR REPLACE FUNCTION @extschema@.CDB_QueryTables(query text)
 RETURNS name[]
 AS $$
 BEGIN
-  RETURN CDB_QueryTablesText(query)::name[];
+  RETURN @extschema@.CDB_QueryTablesText(query)::name[];
 END
 $$ LANGUAGE 'plpgsql' VOLATILE STRICT PARALLEL UNSAFE;

--- a/scripts-available/CDB_RandomTids.sql
+++ b/scripts-available/CDB_RandomTids.sql
@@ -15,7 +15,7 @@
 --
 --
 -- }{
-CREATE OR REPLACE FUNCTION CDB_RandomTids(in_table regclass, in_nsamples integer)
+CREATE OR REPLACE FUNCTION @extschema@.CDB_RandomTids(in_table regclass, in_nsamples integer)
   RETURNS tid[]
 AS $$
 DECLARE

--- a/scripts-available/CDB_RectangleGrid.sql
+++ b/scripts-available/CDB_RectangleGrid.sql
@@ -1,5 +1,5 @@
 -- In older versions of the extension, CDB_RectangleGrid had a different signature
-DROP FUNCTION IF EXISTS cartodb.CDB_RectangleGrid(GEOMETRY, FLOAT8, FLOAT8, GEOMETRY);
+DROP FUNCTION IF EXISTS @extschema@.CDB_RectangleGrid(GEOMETRY, FLOAT8, FLOAT8, GEOMETRY);
 
 --
 -- Fill given extent with a rectangular coverage
@@ -22,7 +22,7 @@ DROP FUNCTION IF EXISTS cartodb.CDB_RectangleGrid(GEOMETRY, FLOAT8, FLOAT8, GEOM
 --                 if the grid requires more cells to cover the extent
 --                 and exception will occur.
 --
-CREATE OR REPLACE FUNCTION CDB_RectangleGrid(ext GEOMETRY, width FLOAT8, height FLOAT8, origin GEOMETRY DEFAULT NULL, maxcells INTEGER DEFAULT 512*512)
+CREATE OR REPLACE FUNCTION @extschema@.CDB_RectangleGrid(ext GEOMETRY, width FLOAT8, height FLOAT8, origin GEOMETRY DEFAULT NULL, maxcells INTEGER DEFAULT 512*512)
 RETURNS SETOF GEOMETRY
 AS $$
 DECLARE
@@ -44,17 +44,17 @@ DECLARE
   srid INTEGER;
 BEGIN
 
-  srid := ST_SRID(ext);
+  srid := @postgisschema@.ST_SRID(ext);
 
   xoff := 0; 
   yoff := 0;
 
   IF origin IS NOT NULL THEN
-    IF ST_SRID(origin) != srid THEN
+    IF @postgisschema@.ST_SRID(origin) != srid THEN
       RAISE EXCEPTION 'SRID mismatch between extent (%) and origin (%)', srid, ST_SRID(origin);
     END IF;
-    xoff := ST_X(origin);
-    yoff := ST_Y(origin);
+    xoff := @postgisschema@.ST_X(origin);
+    yoff := @postgisschema@.ST_Y(origin);
   END IF;
 
   --RAISE DEBUG 'X offset: %', xoff;
@@ -72,11 +72,11 @@ BEGIN
   vstep := height;
 
   -- Tweak horizontal start on hstep grid from origin 
-  hstart := xoff + ceil((ST_XMin(ext)-xoff)/hstep)*hstep; 
+  hstart := xoff + ceil((@postgisschema@.ST_XMin(ext)-xoff)/hstep)*hstep; 
   --RAISE DEBUG 'hstart: %', hstart;
 
   -- Tweak vertical start on vstep grid from origin 
-  vstart := yoff + ceil((ST_Ymin(ext)-yoff)/vstep)*vstep; 
+  vstart := yoff + ceil((@postgisschema@.ST_Ymin(ext)-yoff)/vstep)*vstep; 
   --RAISE DEBUG 'vstart: %', vstart;
 
   hend := ST_XMax(ext);
@@ -94,10 +94,10 @@ BEGIN
   x := hstart;
   WHILE x < hend LOOP -- over X
     y := vstart;
-    h := ST_MakeEnvelope(x-hw, y-hh, x+hw, y+hh, srid);
+    h := @postgisschema@.ST_MakeEnvelope(x-hw, y-hh, x+hw, y+hh, srid);
     WHILE y < vend LOOP -- over Y
       RETURN NEXT h;
-      h := ST_Translate(h, 0, vstep);
+      h := @postgisschema@.ST_Translate(h, 0, vstep);
       y := yoff + round(((y + vstep)-yoff)/ygrd)*ygrd; -- round to grid
     END LOOP;
     x := xoff + round(((x + hstep)-xoff)/xgrd)*xgrd; -- round to grid

--- a/scripts-available/CDB_SearchPath.sql
+++ b/scripts-available/CDB_SearchPath.sql
@@ -1,4 +1,4 @@
----- Make sure 'cartodb' is in database search path
+---- Make sure '@extschema@' is in database search path
 DO
 $$
 DECLARE
@@ -8,13 +8,13 @@ BEGIN
   SELECT reset_val INTO var_cur_search_path
   FROM pg_settings WHERE name = 'search_path';
 
-  IF var_cur_search_path LIKE '%cartodb%' THEN
-    RAISE DEBUG '"cartodb" already in database search_path';
+  IF var_cur_search_path LIKE '%@extschema@%' THEN
+    RAISE DEBUG '"@extschema@" already in database search_path';
   ELSE
-    var_cur_search_path := var_cur_search_path || ', "cartodb"';
+    var_cur_search_path := var_cur_search_path || ', "@extschema@"';
     EXECUTE 'ALTER DATABASE ' || quote_ident(current_database()) ||
             ' SET search_path = ' || var_cur_search_path;
-    RAISE DEBUG '"cartodb" has been added to end of database search_path';
+    RAISE DEBUG '"@extschema@" has been added to end of database search_path';
   END IF;
 
   -- Reset search_path

--- a/scripts-available/CDB_Stats.sql
+++ b/scripts-available/CDB_Stats.sql
@@ -9,7 +9,7 @@
 --
 
 -- Calculate kurtosis
-CREATE OR REPLACE FUNCTION CDB_Kurtosis ( in_array NUMERIC[] ) RETURNS NUMERIC as $$
+CREATE OR REPLACE FUNCTION @extschema@.CDB_Kurtosis ( in_array NUMERIC[] ) RETURNS NUMERIC as $$
 DECLARE
     a numeric;
     c numeric;
@@ -32,7 +32,7 @@ END;
 $$ language plpgsql IMMUTABLE STRICT PARALLEL SAFE;
 
 -- Calculate skewness
-CREATE OR REPLACE FUNCTION CDB_Skewness ( in_array NUMERIC[] ) RETURNS NUMERIC as $$
+CREATE OR REPLACE FUNCTION @extschema@.CDB_Skewness ( in_array NUMERIC[] ) RETURNS NUMERIC as $$
 DECLARE
     a numeric;
     c numeric;

--- a/scripts-available/CDB_StringToDate.sql
+++ b/scripts-available/CDB_StringToDate.sql
@@ -1,7 +1,7 @@
 -- Convert string to date
 --
-DROP FUNCTION IF EXISTS CDB_StringToDate(character varying);
-CREATE OR REPLACE FUNCTION CDB_StringToDate(input character varying)
+DROP FUNCTION IF EXISTS @extschema@.CDB_StringToDate(character varying);
+CREATE OR REPLACE FUNCTION @extschema@.CDB_StringToDate(input character varying)
 RETURNS TIMESTAMP AS $$
 DECLARE output TIMESTAMP;
 BEGIN

--- a/scripts-available/CDB_TableIndexes.sql
+++ b/scripts-available/CDB_TableIndexes.sql
@@ -1,5 +1,5 @@
 -- Function returning indexes for a table
-CREATE OR REPLACE FUNCTION CDB_TableIndexes(REGCLASS)
+CREATE OR REPLACE FUNCTION @extschema@.CDB_TableIndexes(REGCLASS)
 RETURNS TABLE(index_name name, index_unique bool, index_primary bool, index_keys text array)
 AS $$
 
@@ -24,4 +24,4 @@ $$ LANGUAGE SQL STABLE PARALLEL SAFE;
 
 -- This is to migrate from pre-0.2.0 version
 -- See http://github.com/CartoDB/cartodb-postgresql/issues/36
-GRANT EXECUTE ON FUNCTION CDB_TableIndexes(REGCLASS) TO public;
+GRANT EXECUTE ON FUNCTION @extschema@.CDB_TableIndexes(REGCLASS) TO public;

--- a/scripts-available/CDB_TransformToWebmercator.sql
+++ b/scripts-available/CDB_TransformToWebmercator.sql
@@ -5,19 +5,19 @@
 -- for web mercator by "clipping" anything outside to the valid
 -- range.
 --
-CREATE OR REPLACE FUNCTION CDB_TransformToWebmercator(geom geometry)
-RETURNS geometry
+CREATE OR REPLACE FUNCTION @extschema@.CDB_TransformToWebmercator(geom @postgisschema@.geometry)
+RETURNS @postgisschema@.geometry
 AS
 $$
 DECLARE
-  valid_extent GEOMETRY;
-  latlon_input GEOMETRY;
-  clipped_input GEOMETRY;
-  to_webmercator GEOMETRY;
-  ret GEOMETRY;
+  valid_extent @postgisschema@.GEOMETRY;
+  latlon_input @postgisschema@.GEOMETRY;
+  clipped_input @postgisschema@.GEOMETRY;
+  to_webmercator @postgisschema@.GEOMETRY;
+  ret @postgisschema@.GEOMETRY;
 BEGIN
 
-  IF ST_Srid(geom) = 3857 THEN
+  IF @postgisschema@.ST_Srid(geom) = 3857 THEN
     RETURN geom;
   END IF;
 
@@ -27,18 +27,18 @@ BEGIN
   --       to -85.0511 to 85.0511 but as long as proj
   --       does not complain we are happy
   --
-  valid_extent := ST_MakeEnvelope(-180, -89, 180, 89, 4326);
+  valid_extent := @postgisschema@.ST_MakeEnvelope(-180, -89, 180, 89, 4326);
 
   -- Then we transform to WGS84 latlon, which is
   -- where we have known coordinates for the clipping
   --
-  latlon_input := ST_Transform(geom, 4326);
+  latlon_input := @postgisschema@.ST_Transform(geom, 4326);
 
   -- Don't bother clipping if the geometry boundary doesn't
   -- go outside the valid extent.
   IF latlon_input @ valid_extent THEN
     BEGIN
-      RETURN ST_Transform(latlon_input, 3857);
+      RETURN @postgisschema@.ST_Transform(latlon_input, 3857);
     EXCEPTION WHEN OTHERS THEN
       RETURN NULL;
     END;
@@ -47,33 +47,33 @@ BEGIN
   -- Since we're going to use ST_Intersection on input
   -- we'd better ensure the input is valid
   -- TODO: only do this if the first ST_Intersection fails ?
-  IF ST_Dimension(geom) != 0 AND 
+  IF @postgisschema@.ST_Dimension(geom) != 0 AND 
       -- See http://trac.osgeo.org/postgis/ticket/1719
-     GeometryType(geom) != 'GEOMETRYCOLLECTION'
+     @postgisschema@.GeometryType(geom) != 'GEOMETRYCOLLECTION'
   THEN
     BEGIN
-      latlon_input := ST_MakeValid(latlon_input);
+      latlon_input := @postgisschema@.ST_MakeValid(latlon_input);
     EXCEPTION
       WHEN OTHERS THEN
         -- See http://github.com/Vizzuality/cartodb/issues/931
         RAISE WARNING 'Could not clean input geometry: %', SQLERRM;
         RETURN NULL;
     END;
-    latlon_input := ST_CollectionExtract(latlon_input, ST_Dimension(geom)+1);
+    latlon_input := @postgisschema@.ST_CollectionExtract(latlon_input, ST_Dimension(geom)+1);
   END IF;
 
   -- Then we clip, trying to retain the input type
   -- TODO: catch exceptions here too ?
-  clipped_input := ST_Intersection(latlon_input, valid_extent);
+  clipped_input := @postgisschema@.ST_Intersection(latlon_input, valid_extent);
 
   -- We transform to web mercator
-  to_webmercator := ST_Transform(clipped_input, 3857);
+  to_webmercator := @postgisschema@.ST_Transform(clipped_input, 3857);
 
   -- Finally we convert EMPTY to NULL
   -- See https://github.com/Vizzuality/cartodb/issues/706
   -- And retain "multi" status
-  ret := CASE WHEN ST_IsEmpty(to_webmercator) THEN NULL::geometry
-      WHEN GeometryType(geom) LIKE 'MULTI%' THEN ST_Multi(to_webmercator)
+  ret := CASE WHEN @postgisschema@.ST_IsEmpty(to_webmercator) THEN NULL::@postgisschema@.geometry
+      WHEN @postgisschema@.GeometryType(geom) LIKE 'MULTI%' THEN @postgisschema@.ST_Multi(to_webmercator)
       ELSE to_webmercator
   END;
 

--- a/scripts-available/CDB_UserTables.sql
+++ b/scripts-available/CDB_UserTables.sql
@@ -5,8 +5,8 @@
 --
 -- Currently accepted permissions are: 'public', 'private' or 'all'
 --
-DROP FUNCTION IF EXISTS CDB_UserTables(text);
-CREATE OR REPLACE FUNCTION CDB_UserTables(perm text DEFAULT 'all')
+DROP FUNCTION IF EXISTS @extschema@.CDB_UserTables(text);
+CREATE OR REPLACE FUNCTION @extschema@.CDB_UserTables(perm text DEFAULT 'all')
 RETURNS SETOF name
 AS $$
 
@@ -15,7 +15,7 @@ FROM pg_class c
 JOIN pg_namespace n ON n.oid = c.relnamespace
 WHERE c.relkind = 'r' 
 AND c.relname NOT IN ('cdb_tablemetadata', 'cdb_analysis_catalog', 'cdb_conf', 'spatial_ref_sys')
-AND n.nspname NOT IN ('pg_catalog', 'information_schema', 'topology', 'cartodb')
+AND n.nspname NOT IN ('pg_catalog', 'information_schema', 'topology', '@extschema@')
 AND CASE WHEN perm = 'public' THEN has_table_privilege('publicuser', c.oid, 'SELECT')
          WHEN perm = 'private' THEN has_table_privilege(current_user, c.oid, 'SELECT') AND NOT has_table_privilege('publicuser', c.oid, 'SELECT')
          WHEN perm = 'all' THEN has_table_privilege(current_user, c.oid, 'SELECT') OR has_table_privilege('publicuser', c.oid, 'SELECT')
@@ -25,4 +25,4 @@ $$ LANGUAGE 'sql' STABLE PARALLEL SAFE;
 
 -- This is to migrate from pre-0.2.0 version
 -- See http://github.com/CartoDB/cartodb-postgresql/issues/36
-GRANT EXECUTE ON FUNCTION CDB_UserTables(text) TO public;
+GRANT EXECUTE ON FUNCTION @extschema@.CDB_UserTables(text) TO public;

--- a/scripts-available/CDB_Username.sql
+++ b/scripts-available/CDB_Username.sql
@@ -1,6 +1,6 @@
 -- Returns the cartodb username of the current PostgreSQL session
-CREATE OR REPLACE FUNCTION cartodb.CDB_Username()
+CREATE OR REPLACE FUNCTION @extschema@.CDB_Username()
 RETURNS text
 AS $$
-  SELECT cartodb.CDB_Conf_GetConf(CONCAT('api_keys_', session_user))->>'username';
+  SELECT @extschema@.CDB_Conf_GetConf(CONCAT('api_keys_', session_user))->>'username';
 $$ LANGUAGE SQL STABLE PARALLEL SAFE SECURITY DEFINER;

--- a/scripts-available/CDB_XYZ.sql
+++ b/scripts-available/CDB_XYZ.sql
@@ -1,7 +1,7 @@
 -- {
 -- Return pixel resolution at the given zoom level
 -- }{
-CREATE OR REPLACE FUNCTION CDB_XYZ_Resolution(z INTEGER)
+CREATE OR REPLACE FUNCTION @extschema@.CDB_XYZ_Resolution(z INTEGER)
 RETURNS FLOAT8
 AS $$
   -- circumference divided by 256 is z0 resolution, then divide by 2^z
@@ -15,7 +15,7 @@ $$ LANGUAGE SQL IMMUTABLE PARALLEL SAFE STRICT;
 -- SRID of the returned polygon is forceably 3857
 --
 -- }{
-CREATE OR REPLACE FUNCTION CDB_XYZ_Extent(x INTEGER, y INTEGER, z INTEGER)
+CREATE OR REPLACE FUNCTION @extschema@.CDB_XYZ_Extent(x INTEGER, y INTEGER, z INTEGER)
 RETURNS GEOMETRY
 AS $$
 DECLARE
@@ -34,7 +34,7 @@ BEGIN
   -- Size of each tile in pixels (1:1 aspect ratio)
   tile_size := 256;
 
-  initial_resolution := CDB_XYZ_Resolution(0);
+  initial_resolution := @extschema@.CDB_XYZ_Resolution(0);
   --RAISE DEBUG 'Initial resolution: %', initial_resolution;
 
   origin_shift := (initial_resolution * tile_size) / 2.0;
@@ -56,7 +56,7 @@ BEGIN
   --RAISE DEBUG 'ymin: %', ymin;
   --RAISE DEBUG 'ymax: %', ymax;
   
-  RETURN ST_MakeEnvelope(xmin, ymin, xmax, ymax, 3857);
+  RETURN @postgisschema@.ST_MakeEnvelope(xmin, ymin, xmax, ymax, 3857);
 END
 $$ LANGUAGE 'plpgsql' IMMUTABLE STRICT PARALLEL SAFE;
 -- }

--- a/scripts-available/CDB_ZoomFromScale.sql
+++ b/scripts-available/CDB_ZoomFromScale.sql
@@ -1,5 +1,5 @@
 -- Maximum supported zoom level
-CREATE OR REPLACE FUNCTION _CDB_MaxSupportedZoom()
+CREATE OR REPLACE FUNCTION @extschema@._CDB_MaxSupportedZoom()
 RETURNS int
 LANGUAGE SQL
 IMMUTABLE PARALLEL SAFE
@@ -12,7 +12,7 @@ AS $$
   SELECT 29;
 $$;
 
-CREATE OR REPLACE FUNCTION cartodb.CDB_ZoomFromScale(scaleDenominator numeric)
+CREATE OR REPLACE FUNCTION @extschema@.CDB_ZoomFromScale(scaleDenominator numeric)
 RETURNS int
 LANGUAGE SQL
 IMMUTABLE PARALLEL SAFE
@@ -24,12 +24,12 @@ AS $$
         NULL
       WHEN scaleDenominator = 0 THEN
         -- Actual zoom level would be infinite
-        _CDB_MaxSupportedZoom()
+        @extschema@._CDB_MaxSupportedZoom()
       ELSE
         CAST (
           LEAST(
             ROUND(LOG(2, 559082264.028/scaleDenominator)),
-            _CDB_MaxSupportedZoom()
+            @extschema@._CDB_MaxSupportedZoom()
           )
         AS INTEGER)
     END;

--- a/test/CDB_UserTablesTest.sql
+++ b/test/CDB_UserTablesTest.sql
@@ -1,4 +1,18 @@
-CREATE ROLE publicuser LOGIN;
+SET client_min_messages TO ERROR;
+DO
+$do$
+BEGIN
+   IF NOT EXISTS (
+      SELECT *
+      FROM   pg_catalog.pg_user
+      WHERE  usename = 'publicuser') THEN
+
+      CREATE ROLE publicuser LOGIN;
+   END IF;
+END
+$do$;
+SET client_min_messages TO NOTICE;
+
 CREATE TABLE pub(a int);
 CREATE TABLE prv(a int);
 GRANT SELECT ON TABLE pub TO publicuser;
@@ -16,4 +30,3 @@ SELECT 'private_publicuser',CDB_UserTables('private') ORDER BY 2;
 \c contrib_regression postgres
 DROP TABLE pub;
 DROP TABLE prv;
-DROP ROLE publicuser;

--- a/test/CDB_UserTablesTest_expect
+++ b/test/CDB_UserTablesTest_expect
@@ -1,4 +1,6 @@
-CREATE ROLE
+SET
+DO
+SET
 CREATE TABLE
 CREATE TABLE
 GRANT
@@ -15,4 +17,3 @@ public_publicuser|pub
 You are now connected to database "contrib_regression" as user "postgres".
 DROP TABLE
 DROP TABLE
-DROP ROLE

--- a/test/organization/test.sh
+++ b/test/organization/test.sh
@@ -253,9 +253,6 @@ function run_tests() {
     setup
     for t in ${TESTS}
     do
-#         if [[ ${t} != "test_cdb_usertables_should_work_with_orgusers" ]]; then
-#             continue;
-#         fi
         echo "####################################################################"
         echo "#"
         echo "# Running: ${t}"

--- a/test/organization/test.sh
+++ b/test/organization/test.sh
@@ -10,7 +10,6 @@
 DATABASE=test_organizations
 CMD=psql
 SED=sed
-PG_PARALLEL=$(pg_config --version | awk '{$2*=1000; if ($2 >= 9600) print 1; else print 0;}' 2> /dev/null || echo 0)
 
 OK=0
 PARTIALOK=0
@@ -24,19 +23,6 @@ function set_failed() {
 function clear_partial_result() {
     PARTIALOK=0
 }
-
-function load_sql_file() {
-    if [[ $PG_PARALLEL -eq 0 ]]
-    then
-        tmp_file=/tmp/$(basename $1)_no_parallel
-        ${SED} $1 -e 's/PARALLEL \= [A-Z]*/''/g' -e 's/PARALLEL [A-Z]*/''/g' > $tmp_file
-        ${CMD} -d ${DATABASE} -f $tmp_file
-        rm $tmp_file
-    else
-        ${CMD} -d ${DATABASE} -f $1
-    fi
-}
-
 
 function sql() {
     local ROLE
@@ -146,6 +132,7 @@ function create_role_and_schema() {
     sql "GRANT CONNECT ON DATABASE \"${DATABASE}\" TO ${ROLE};"
     sql "CREATE SCHEMA ${ROLE} AUTHORIZATION ${ROLE};"
     sql "SELECT cartodb.CDB_Organization_Create_Member('${ROLE}')"
+    sql "ALTER ROLE ${ROLE} SET search_path TO ${ROLE},cartodb,public;"
 }
 
 
@@ -168,34 +155,46 @@ function create_table() {
     sql ${ROLE} "CREATE TABLE ${ROLE}.${TABLENAME} ( a int );"
 }
 
+function truncate_table() {
+    if [[ $# -ne 2 ]]
+    then
+        log_error "truncate_table requires two arguments: role and table_name"
+        exit 1
+    fi
+    local ROLE="$1"
+    local TABLENAME="$2"
+    sql ${ROLE} "TRUNCATE TABLE ${ROLE}.${TABLENAME};"
+}
+
 
 function setup() {
     ${CMD} -c "CREATE DATABASE ${DATABASE}"
-    sql "CREATE SCHEMA cartodb;"
-    sql "CREATE EXTENSION plpythonu;"
-    sql "GRANT USAGE ON SCHEMA cartodb TO public;"
+    ${CMD} -c "ALTER DATABASE ${DATABASE} SET search_path = public, cartodb;"
+    sql "CREATE EXTENSION cartodb CASCADE;"
+    ${CMD} -c "ALTER DATABASE ${DATABASE} SET search_path = public, cartodb;"
 
-    log_info "########################### BOOTSTRAP ###########################"
-    load_sql_file scripts-available/CDB_Organizations.sql
-    load_sql_file scripts-available/CDB_Conf.sql
-    load_sql_file scripts-available/CDB_Groups.sql
-    load_sql_file scripts-available/CDB_Groups_API.sql
 
     log_info "############################# SETUP #############################"
     create_role_and_schema cdb_org_admin
     sql "SELECT cartodb.CDB_Organization_AddAdmin('cdb_org_admin');"
     create_role_and_schema cdb_testmember_1
     create_role_and_schema cdb_testmember_2
-    sql "CREATE ROLE publicuser LOGIN;"
+    sql postgres "DO
+\$\$
+BEGIN
+   IF NOT EXISTS (
+      SELECT *
+      FROM   pg_catalog.pg_user
+      WHERE  usename = 'publicuser') THEN
+
+      CREATE ROLE publicuser LOGIN;
+   END IF;
+END
+\$\$;"
     sql "GRANT CONNECT ON DATABASE \"${DATABASE}\" TO publicuser;"
 
     create_table cdb_testmember_1 foo
-    sql cdb_testmember_1 'INSERT INTO cdb_testmember_1.foo VALUES (1), (2), (3), (4), (5);'
-    sql cdb_testmember_1 'SELECT * FROM cdb_testmember_1.foo;'
-
     create_table cdb_testmember_2 bar
-    sql cdb_testmember_2 'INSERT INTO bar VALUES (1), (2), (3), (4), (5);'
-    sql cdb_testmember_2 'SELECT * FROM cdb_testmember_2.bar;'
 
     sql "SELECT cartodb.CDB_Group_CreateGroup('group_a_tmp')"
     sql "SELECT cartodb.CDB_Group_RenameGroup('group_a_tmp', 'group_a')"
@@ -235,7 +234,6 @@ function tear_down() {
 
     sql 'DROP ROLE cdb_testmember_1;'
     sql 'DROP ROLE cdb_testmember_2;'
-    sql 'DROP ROLE publicuser;'
     sql 'DROP ROLE cdb_org_admin;'
 
     ${CMD} -c "DROP DATABASE ${DATABASE}"
@@ -251,23 +249,28 @@ function run_tests() {
     else
         TESTS=`cat $0 | perl -n -e'/function (test.*)\(\)/ && print "$1\n"'`
     fi
+
+    setup
     for t in ${TESTS}
     do
+#         if [[ ${t} != "test_cdb_usertables_should_work_with_orgusers" ]]; then
+#             continue;
+#         fi
         echo "####################################################################"
         echo "#"
         echo "# Running: ${t}"
         echo "#"
         echo "####################################################################"
         clear_partial_result
-        setup
         log_info "############################# TESTS #############################"
         eval ${t}
         if [[ ${PARTIALOK} -ne 0 ]]
         then
             FAILED_TESTS+=(${t})
         fi
-        tear_down
     done
+    tear_down
+
     if [[ ${OK} -ne 0 ]]
     then
         echo
@@ -289,9 +292,14 @@ function test_member_1_cannot_grant_read_permission_to_other_schema_than_its_one
 }
 
 function test_member_1_grants_read_permission_and_member_2_can_read() {
+    sql cdb_testmember_1 'INSERT INTO cdb_testmember_1.foo VALUES (5), (6), (7), (8), (9);'
     sql cdb_testmember_1 "SELECT * FROM cartodb.CDB_Organization_Add_Table_Read_Permission('cdb_testmember_1', 'foo', 'cdb_testmember_2')"
     sql cdb_testmember_2 'SELECT count(*) FROM cdb_testmember_1.foo;' should 5
     sql cdb_testmember_1 'SELECT count(*) FROM cdb_testmember_2.bar;' fails
+
+    # Cleanup
+    truncate_table cdb_testmember_1 foo
+    sql cdb_testmember_1 "SELECT * FROM cartodb.CDB_Organization_Remove_Access_Permission('cdb_testmember_1', 'foo', 'cdb_testmember_2')"
 }
 
 function test_member_2_cannot_add_table_to_member_1_schema_after_table_permission_added() {
@@ -300,10 +308,18 @@ function test_member_2_cannot_add_table_to_member_1_schema_after_table_permissio
 }
 
 function test_grant_read_permission_between_two_members() {
+    sql cdb_testmember_1 'INSERT INTO cdb_testmember_1.foo VALUES (5), (6), (7), (8), (9);'
+    sql cdb_testmember_2 'INSERT INTO cdb_testmember_2.bar VALUES (5), (6), (7), (8), (9);'
     sql cdb_testmember_1 "SELECT * FROM cartodb.CDB_Organization_Add_Table_Read_Permission('cdb_testmember_1', 'foo', 'cdb_testmember_2')"
     sql cdb_testmember_2 "SELECT * FROM cartodb.CDB_Organization_Add_Table_Read_Permission('cdb_testmember_2', 'bar', 'cdb_testmember_1')"
     sql cdb_testmember_2 'SELECT count(*) FROM cdb_testmember_1.foo;' should 5
     sql cdb_testmember_1 'SELECT count(*) FROM cdb_testmember_2.bar;' should 5
+
+    # Cleanup
+    truncate_table cdb_testmember_1 foo
+    truncate_table cdb_testmember_2 bar
+    sql cdb_testmember_1 "SELECT * FROM cartodb.CDB_Organization_Remove_Access_Permission('cdb_testmember_1', 'foo', 'cdb_testmember_2')"
+    sql cdb_testmember_2 "SELECT * FROM cartodb.CDB_Organization_Remove_Access_Permission('cdb_testmember_2', 'bar', 'cdb_testmember_1')"
 }
 
 function test_member_2_cannot_write_to_member_1_table() {
@@ -317,11 +333,15 @@ function test_member_1_cannot_grant_read_write_permission_to_other_schema_than_i
 function test_member_2_can_write_to_member_1_table_after_write_permission_is_added() {
     sql cdb_testmember_1 "SELECT * FROM cartodb.CDB_Organization_Add_Table_Read_Write_Permission('cdb_testmember_1', 'foo', 'cdb_testmember_2')"
     sql cdb_testmember_2 'INSERT INTO cdb_testmember_1.foo VALUES (5), (6), (7), (8), (9);'
-    sql cdb_testmember_1 'SELECT count(*) FROM cdb_testmember_1.foo;' should 10
-    sql cdb_testmember_2 'SELECT count(*) FROM cdb_testmember_1.foo;' should 10
+    sql cdb_testmember_1 'SELECT count(*) FROM cdb_testmember_1.foo;' should 5
+    sql cdb_testmember_2 'SELECT count(*) FROM cdb_testmember_1.foo;' should 5
     sql cdb_testmember_2 'DELETE FROM cdb_testmember_1.foo where a = 9;'
-    sql cdb_testmember_1 'SELECT count(*) FROM cdb_testmember_1.foo;' should 9
-    sql cdb_testmember_2 'SELECT count(*) FROM cdb_testmember_1.foo;' should 9
+    sql cdb_testmember_1 'SELECT count(*) FROM cdb_testmember_1.foo;' should 4
+    sql cdb_testmember_2 'SELECT count(*) FROM cdb_testmember_1.foo;' should 4
+
+    # Cleanup
+    truncate_table cdb_testmember_1 foo
+    sql cdb_testmember_1 "SELECT * FROM cartodb.CDB_Organization_Remove_Access_Permission('cdb_testmember_1', 'foo', 'cdb_testmember_2')"
 }
 
 function test_member_2_can_write_to_member_1_table_and_sequence_after_write_permission_is_added() {
@@ -329,13 +349,17 @@ function test_member_2_can_write_to_member_1_table_and_sequence_after_write_perm
 
     sql cdb_testmember_1 "SELECT * FROM cartodb.CDB_Organization_Add_Table_Read_Write_Permission('cdb_testmember_1', 'foo', 'cdb_testmember_2')"
     sql cdb_testmember_2 'INSERT INTO cdb_testmember_1.foo VALUES (5), (6), (7), (8), (9);'
-    sql cdb_testmember_1 'SELECT count(*) FROM cdb_testmember_1.foo;' should 10
-    sql cdb_testmember_2 'SELECT count(*) FROM cdb_testmember_1.foo;' should 10
+    sql cdb_testmember_1 'SELECT count(*) FROM cdb_testmember_1.foo;' should 5
+    sql cdb_testmember_2 'SELECT count(*) FROM cdb_testmember_1.foo;' should 5
     sql cdb_testmember_2 'DELETE FROM cdb_testmember_1.foo where a = 9;'
-    sql cdb_testmember_1 'SELECT count(*) FROM cdb_testmember_1.foo;' should 9
-    sql cdb_testmember_2 'SELECT count(*) FROM cdb_testmember_1.foo;' should 9
+    sql cdb_testmember_1 'SELECT count(*) FROM cdb_testmember_1.foo;' should 4
+    sql cdb_testmember_2 'SELECT count(*) FROM cdb_testmember_1.foo;' should 4
 
     sql cdb_testmember_1 "ALTER TABLE cdb_testmember_1.foo DROP cartodb_id;"
+
+    # Cleanup
+    truncate_table cdb_testmember_1 foo
+    sql cdb_testmember_1 "SELECT * FROM cartodb.CDB_Organization_Remove_Access_Permission('cdb_testmember_1', 'foo', 'cdb_testmember_2')"
 }
 
 function test_member_2_can_write_to_member_1_table_with_non_sequence_cartodb_id_after_write_permission_is_added() {
@@ -343,20 +367,28 @@ function test_member_2_can_write_to_member_1_table_with_non_sequence_cartodb_id_
 
     sql cdb_testmember_1 "SELECT * FROM cartodb.CDB_Organization_Add_Table_Read_Write_Permission('cdb_testmember_1', 'foo', 'cdb_testmember_2')"
     sql cdb_testmember_2 'INSERT INTO cdb_testmember_1.foo VALUES (5), (6), (7), (8), (9);'
-    sql cdb_testmember_1 'SELECT count(*) FROM cdb_testmember_1.foo;' should 10
-    sql cdb_testmember_2 'SELECT count(*) FROM cdb_testmember_1.foo;' should 10
+    sql cdb_testmember_1 'SELECT count(*) FROM cdb_testmember_1.foo;' should 5
+    sql cdb_testmember_2 'SELECT count(*) FROM cdb_testmember_1.foo;' should 5
     sql cdb_testmember_2 'DELETE FROM cdb_testmember_1.foo where a = 9;'
-    sql cdb_testmember_1 'SELECT count(*) FROM cdb_testmember_1.foo;' should 9
-    sql cdb_testmember_2 'SELECT count(*) FROM cdb_testmember_1.foo;' should 9
+    sql cdb_testmember_1 'SELECT count(*) FROM cdb_testmember_1.foo;' should 4
+    sql cdb_testmember_2 'SELECT count(*) FROM cdb_testmember_1.foo;' should 4
 
     sql cdb_testmember_1 "ALTER TABLE cdb_testmember_1.foo DROP cartodb_id;"
+
+    # Cleanup
+    truncate_table cdb_testmember_1 foo
+    sql cdb_testmember_1 "SELECT * FROM cartodb.CDB_Organization_Remove_Access_Permission('cdb_testmember_1', 'foo', 'cdb_testmember_2')"
 }
 
 function test_member_1_removes_access_and_member_2_can_no_longer_query_the_table() {
+    sql cdb_testmember_1 'INSERT INTO cdb_testmember_1.foo VALUES (5), (6), (7), (8), (9), (10);'
     sql cdb_testmember_1 "SELECT * FROM cartodb.CDB_Organization_Add_Table_Read_Permission('cdb_testmember_1', 'foo', 'cdb_testmember_2')"
-    sql cdb_testmember_2 'SELECT count(*) FROM cdb_testmember_1.foo;' should 5
+    sql cdb_testmember_2 'SELECT count(*) FROM cdb_testmember_1.foo;' should 6
     sql cdb_testmember_1 "SELECT * FROM cartodb.CDB_Organization_Remove_Access_Permission('cdb_testmember_1', 'foo', 'cdb_testmember_2')"
     sql cdb_testmember_2 'SELECT * FROM cdb_testmember_1.foo;' fails
+
+    # Cleanup
+    truncate_table cdb_testmember_1 foo
 }
 
 function test_member_1_removes_access_and_member_2_can_no_longer_write_to_the_table() {
@@ -364,12 +396,16 @@ function test_member_1_removes_access_and_member_2_can_no_longer_write_to_the_ta
     sql cdb_testmember_2 'INSERT INTO cdb_testmember_1.foo VALUES (5), (6), (7), (8), (9);'
     sql cdb_testmember_1 "SELECT * FROM cartodb.CDB_Organization_Remove_Access_Permission('cdb_testmember_1', 'foo', 'cdb_testmember_2')"
     sql cdb_testmember_2 'INSERT INTO cdb_testmember_1.foo VALUES (5), (6), (7), (8), (9);' fails
+
+    # Cleanup
+    truncate_table cdb_testmember_1 foo
 }
 
 function test_giving_permissions_to_two_tables_and_removing_from_first_table_should_not_remove_from_second() {
     #### test setup
     # create an extra table for cdb_testmember_1
     create_table cdb_testmember_1 foo_2
+    sql cdb_testmember_1 'INSERT INTO cdb_testmember_1.foo VALUES (1), (2), (3), (4);'
     sql cdb_testmember_1 'INSERT INTO cdb_testmember_1.foo_2 VALUES (1), (2), (3), (4), (5);'
     sql cdb_testmember_1 'SELECT * FROM cdb_testmember_1.foo_2;'
 
@@ -378,7 +414,7 @@ function test_giving_permissions_to_two_tables_and_removing_from_first_table_sho
     sql cdb_testmember_1 "SELECT * FROM cartodb.CDB_Organization_Add_Table_Read_Permission('cdb_testmember_1', 'foo_2', 'cdb_testmember_2')"
 
     # cdb_testmember_2 has access to both tables
-    sql cdb_testmember_2 'SELECT count(*) FROM cdb_testmember_1.foo;' should 5
+    sql cdb_testmember_2 'SELECT count(*) FROM cdb_testmember_1.foo;' should 4
     sql cdb_testmember_2 'SELECT count(*) FROM cdb_testmember_1.foo_2;' should 5
 
     # cdb_testmember_1 removes access to foo table
@@ -390,57 +426,60 @@ function test_giving_permissions_to_two_tables_and_removing_from_first_table_sho
 
 
     #### test tear down
+    truncate_table cdb_testmember_1 foo
     sql cdb_testmember_1 'DROP TABLE cdb_testmember_1.foo_2;'
 }
 
 function test_cdb_org_member_role_allows_reading_to_all_users_without_explicit_permission() {
+    sql cdb_testmember_1 'INSERT INTO cdb_testmember_1.foo VALUES (1), (2), (3), (4);'
+
     sql cdb_testmember_2 'SELECT count(*) FROM cdb_testmember_1.foo;' fails
     sql cdb_testmember_1 "SELECT cartodb.CDB_Organization_Add_Table_Organization_Read_Permission('cdb_testmember_1', 'foo');"
-    sql cdb_testmember_2 'SELECT count(*) FROM cdb_testmember_1.foo;' should 5
+    sql cdb_testmember_2 'SELECT count(*) FROM cdb_testmember_1.foo;' should 4
+
+    # Cleanup
+    sql cdb_testmember_1 "SELECT cartodb.CDB_Organization_Remove_Organization_Access_Permission('cdb_testmember_1', 'foo');"
+    truncate_table cdb_testmember_1 foo
 }
 
 function test_user_can_read_when_it_has_permission_after_organization_permission_is_removed() {
     create_role_and_schema cdb_testmember_3
+    sql cdb_testmember_1 'INSERT INTO cdb_testmember_1.foo VALUES (1), (2), (3), (4);'
 
     # shares with cdb_testmember_2 and can read but cdb_testmember_3 cannot
     sql cdb_testmember_1 "SELECT * FROM cartodb.CDB_Organization_Add_Table_Read_Permission('cdb_testmember_1', 'foo', 'cdb_testmember_2')"
-    sql cdb_testmember_2 'SELECT count(*) FROM cdb_testmember_1.foo;' should 5
+    sql cdb_testmember_2 'SELECT count(*) FROM cdb_testmember_1.foo;' should 4
     sql cdb_testmember_3 'SELECT count(*) FROM cdb_testmember_1.foo;' fails
 
     # granting to organization allows to read to both: cdb_testmember_2 and cdb_testmember_3
     sql cdb_testmember_1 "SELECT cartodb.CDB_Organization_Add_Table_Organization_Read_Permission('cdb_testmember_1', 'foo');"
-    sql cdb_testmember_2 'SELECT count(*) FROM cdb_testmember_1.foo;' should 5
-    sql cdb_testmember_3 'SELECT count(*) FROM cdb_testmember_1.foo;' should 5
+    sql cdb_testmember_2 'SELECT count(*) FROM cdb_testmember_1.foo;' should 4
+    sql cdb_testmember_3 'SELECT count(*) FROM cdb_testmember_1.foo;' should 4
 
     # removing access from organization should keep permission on cdb_testmember_2 but drop it to cdb_testmember_3
     sql cdb_testmember_1 "SELECT cartodb.CDB_Organization_Remove_Organization_Access_Permission('cdb_testmember_1', 'foo');"
-    sql cdb_testmember_2 'SELECT count(*) FROM cdb_testmember_1.foo;' should 5
+    sql cdb_testmember_2 'SELECT count(*) FROM cdb_testmember_1.foo;' should 4
     sql cdb_testmember_3 'SELECT count(*) FROM cdb_testmember_1.foo;' fails
 
+    # Cleanup
+    sql cdb_testmember_1 "SELECT * FROM cartodb.CDB_Organization_Remove_Access_Permission('cdb_testmember_1', 'foo', 'cdb_testmember_2')"
+    truncate_table cdb_testmember_1 foo
     drop_role_and_schema cdb_testmember_3
 }
 
 function test_cdb_querytables_returns_schema_and_table_name() {
-    load_sql_file scripts-available/CDB_QueryStatements.sql
-    load_sql_file scripts-available/CDB_QueryTables.sql
     sql cdb_testmember_1 "select * from CDB_QueryTables('select * from foo');" should "{cdb_testmember_1.foo}"
 }
 
 function test_cdb_querytables_works_with_parentheses() {
-    load_sql_file scripts-available/CDB_QueryStatements.sql
-    load_sql_file scripts-available/CDB_QueryTables.sql
     sql cdb_testmember_1 "select * from CDB_QueryTables('(select * from foo)');" should "{cdb_testmember_1.foo}"
 }
 
 function test_cdb_querytables_returns_schema_and_table_name_for_several_schemas() {
-    load_sql_file scripts-available/CDB_QueryStatements.sql
-    load_sql_file scripts-available/CDB_QueryTables.sql
     sql postgres "select * from CDB_QueryTables('select * from cdb_testmember_1.foo, cdb_testmember_2.bar');" should "{cdb_testmember_1.foo,cdb_testmember_2.bar}"
 }
 
 function test_cdb_querytables_does_not_return_functions_as_part_of_the_resultset() {
-    load_sql_file scripts-available/CDB_QueryStatements.sql
-    load_sql_file scripts-available/CDB_QueryTables.sql
     sql postgres "select * from CDB_QueryTables('select * from cdb_testmember_1.foo, cdb_testmember_2.bar, plainto_tsquery(''foo'')');" should "{cdb_testmember_1.foo,cdb_testmember_2.bar}"
 }
 
@@ -464,10 +503,6 @@ function test_cdb_usertables_should_work_with_orgusers() {
     # this is required to enable select from other schema
     sql postgres "GRANT USAGE ON SCHEMA cdb_testmember_1 TO publicuser";
 
-
-    # test CDB_UserTables with publicuser
-    load_sql_file scripts-available/CDB_UserTables.sql
-
     sql publicuser "SELECT count(*) FROM CDB_UserTables('all')" should 1
     sql publicuser "SELECT count(*) FROM CDB_UserTables('public')" should 1
     sql publicuser "SELECT count(*) FROM CDB_UserTables('private')" should 0
@@ -483,6 +518,7 @@ function test_cdb_usertables_should_work_with_orgusers() {
     # test cdb_testmember_2 can select from cdb_testmember_1's public table
     sql cdb_testmember_2 "SELECT * FROM cdb_testmember_1.test_perms_pub" should 1
 
+    sql postgres 'REVOKE USAGE ON SCHEMA cdb_testmember_1 FROM publicuser;'
     sql cdb_testmember_1 "DROP TABLE test_perms_pub"
     sql cdb_testmember_1 "DROP TABLE test_perms_priv"
 }

--- a/util/create_from_unpackaged.sh
+++ b/util/create_from_unpackaged.sh
@@ -23,9 +23,9 @@ cat ${input} | grep -v 'duplicated extension$' >> ${output}
 
 # Migrate CDB_TableMetadata
 cat >> ${output} <<'EOF'
-ALTER TABLE cartodb.CDB_TableMetadata DISABLE TRIGGER ALL;
-INSERT INTO cartodb.CDB_TableMetadata SELECT * FROM public.CDB_TableMetadata;
-ALTER TABLE cartodb.CDB_TableMetadata ENABLE TRIGGER ALL;
+ALTER TABLE @extschema@.CDB_TableMetadata DISABLE TRIGGER ALL;
+INSERT INTO @extschema@.CDB_TableMetadata SELECT * FROM public.CDB_TableMetadata;
+ALTER TABLE @extschema@.CDB_TableMetadata ENABLE TRIGGER ALL;
 DROP TABLE public.CDB_TableMetadata;
 
 -- Set user quota
@@ -40,7 +40,7 @@ BEGIN
   EXCEPTION WHEN undefined_function THEN
     RAISE EXCEPTION 'Please set user quota before switching to cartodb extension';
   END;
-  PERFORM cartodb.CDB_SetUserQuotaInBytes(qmax);
+  PERFORM @extschema@.CDB_SetUserQuotaInBytes(qmax);
   DROP FUNCTION public._CDB_UserQuotaInBytes();
 END;
 $$ LANGUAGE 'plpgsql';
@@ -49,7 +49,7 @@ EOF
 ## Cartodbfy tables with a trigger using 'CDB_CheckQuota' or
 ## 'CDB_TableMetadata_Trigger' from the 'public' schema
 #cat >> ${output} <<'EOF'
-#select cartodb.CDB_CartodbfyTable(relname::regclass) from ( 
+#select @extschema@.CDB_CartodbfyTable(relname::regclass) from ( 
 #  -- names of tables using public.CDB_CheckQuota or
 #  -- public.CDB_TableMetadata_Trigger in their triggers
 #  SELECT distinct c.relname

--- a/util/create_from_unpackaged.sh
+++ b/util/create_from_unpackaged.sh
@@ -23,9 +23,9 @@ cat ${input} | grep -v 'duplicated extension$' >> ${output}
 
 # Migrate CDB_TableMetadata
 cat >> ${output} <<'EOF'
-ALTER TABLE @extschema@.CDB_TableMetadata DISABLE TRIGGER ALL;
-INSERT INTO @extschema@.CDB_TableMetadata SELECT * FROM public.CDB_TableMetadata;
-ALTER TABLE @extschema@.CDB_TableMetadata ENABLE TRIGGER ALL;
+ALTER TABLE cartodb.CDB_TableMetadata DISABLE TRIGGER ALL;
+INSERT INTO cartodb.CDB_TableMetadata SELECT * FROM public.CDB_TableMetadata;
+ALTER TABLE cartodb.CDB_TableMetadata ENABLE TRIGGER ALL;
 DROP TABLE public.CDB_TableMetadata;
 
 -- Set user quota
@@ -40,7 +40,7 @@ BEGIN
   EXCEPTION WHEN undefined_function THEN
     RAISE EXCEPTION 'Please set user quota before switching to cartodb extension';
   END;
-  PERFORM @extschema@.CDB_SetUserQuotaInBytes(qmax);
+  PERFORM cartodb.CDB_SetUserQuotaInBytes(qmax);
   DROP FUNCTION public._CDB_UserQuotaInBytes();
 END;
 $$ LANGUAGE 'plpgsql';
@@ -49,7 +49,7 @@ EOF
 ## Cartodbfy tables with a trigger using 'CDB_CheckQuota' or
 ## 'CDB_TableMetadata_Trigger' from the 'public' schema
 #cat >> ${output} <<'EOF'
-#select @extschema@.CDB_CartodbfyTable(relname::regclass) from ( 
+#select cartodb.CDB_CartodbfyTable(relname::regclass) from ( 
 #  -- names of tables using public.CDB_CheckQuota or
 #  -- public.CDB_TableMetadata_Trigger in their triggers
 #  SELECT distinct c.relname


### PR DESCRIPTION
* Fully qualify function calls
* Several improvements to bash tests.
* Avoid dropping publicuser in tests.
* Raise minimum requirement to PostgreSQL 9.6.

Pending:
- [x] Test that it doesn't break builder: Works locally
- [x] Test pg_upgrade (broken right now when an index is created over `cdb_latlng`: Confirmed that it's fixed.
- [ ] Adapt Windshaft / Windshaft-cartodb / SQL-API to the new ways: either patch the SQL files (as it was done with PARALLEL) or try to stop downloading them directly.
- [ ] Upgrade.

Conflicts with https://github.com/CartoDB/cartodb-postgresql/pull/355 (some changes there will be necessary once both are merged).