### PR TITLE
Fix carto-package requirements to be SemVer compliant

### DIFF
--- a/carto-package.json
+++ b/carto-package.json
@@ -2,7 +2,7 @@
     "name": "carto_postgresql_ext",
     "current_version": {
         "requires": {
-            "postgresql": ">=10.0",
+            "postgresql": ">=10.0.0",
             "postgis": ">=2.4.0.0"
         },
         "works_with": {


### PR DESCRIPTION
Our `carto-package` definition requires the versions to be SemVer compliant even if the upstream software is not.