### PR TITLE
Make CDB_Get_Foreign_Updated_At robust to missing CDB_TableMetadata

### DIFF
--- a/scripts-available/CDB_ForeignTable.sql
+++ b/scripts-available/CDB_ForeignTable.sql
@@ -131,8 +131,7 @@ BEGIN
     WHEN undefined_table THEN
       -- If you add a GET STACKED DIAGNOSTICS text_var = RETURNED_SQLSTATE
       -- you get a code 42P01 which corresponds to undefined_table
-      RAISE NOTICE 'CDB_Get_Foreign_Updated_At: could not find %.cdb_tablemetadata while checking % updated_at, returning NOW() timestamp', fdw_schema_name, foreign_table;
-      time := NOW();
+      RAISE NOTICE 'CDB_Get_Foreign_Updated_At: could not find %.cdb_tablemetadata while checking % updated_at, returning NULL timestamp', fdw_schema_name, foreign_table;
   END;
   RETURN time;
 END

--- a/scripts-available/CDB_ForeignTable.sql
+++ b/scripts-available/CDB_ForeignTable.sql
@@ -125,7 +125,15 @@ BEGIN
 
   -- We assume that the remote cdb_tablemetadata is called cdb_tablemetadata and is on the same schema as the queried table.
   SELECT nspname FROM pg_class c, pg_namespace n WHERE c.oid=foreign_table AND c.relnamespace = n.oid INTO fdw_schema_name;
-  EXECUTE FORMAT('SELECT updated_at FROM %I.cdb_tablemetadata WHERE tabname=%L ORDER BY updated_at DESC LIMIT 1', fdw_schema_name, remote_table_name) INTO time;
+  BEGIN
+    EXECUTE FORMAT('SELECT updated_at FROM %I.cdb_tablemetadata WHERE tabname=%L ORDER BY updated_at DESC LIMIT 1', fdw_schema_name, remote_table_name) INTO time;
+  EXCEPTION
+    WHEN undefined_table THEN
+      -- If you add a GET STACKED DIAGNOSTICS text_var = RETURNED_SQLSTATE
+      -- you get a code 42P01 which corresponds to undefined_table
+      RAISE NOTICE 'CDB_Get_Foreign_Updated_At: could not find %.cdb_tablemetadata while checking % updated_at, returning NOW() timestamp', fdw_schema_name, foreign_table;
+      time := NOW();
+  END;
   RETURN time;
 END
 $$

--- a/test/extension/test.sh
+++ b/test/extension/test.sh
@@ -586,6 +586,12 @@ test_extension|public|"local-table-with-dashes"'
     sql postgres "SELECT cartodb.CDB_Last_Updated_Time(ARRAY['test_extension.public.\"local-table-with-dashes\"']::text[]) < now()" should 't'
     sql postgres "SELECT cartodb.CDB_Last_Updated_Time(ARRAY['test_extension.public.\"local-table-with-dashes\"']::text[]) > (now() - interval '1 minute')" should 't'
 
+    # Check CDB_Get_Foreign_Updated_At is robust to unimported CDB_TableMetadata
+    sql postgres "DROP FOREIGN TABLE IF EXISTS test_fdw.cdb_tablemetadata;"
+    sql postgres "SELECT cartodb.CDB_Get_Foreign_Updated_At('test_fdw.foo') < (now() + interval '1 minute')" should 't'
+    sql postgres "SELECT cartodb.CDB_Get_Foreign_Updated_At('test_fdw.foo') > (now() - interval '1 minute')" should 't'
+
+    # Teardown
     DATABASE=fdw_target sql postgres 'REVOKE USAGE ON SCHEMA test_fdw FROM fdw_user;'
     DATABASE=fdw_target sql postgres 'REVOKE SELECT ON test_fdw.foo FROM fdw_user;'
     DATABASE=fdw_target sql postgres 'REVOKE SELECT ON test_fdw.foo2 FROM fdw_user;'

--- a/test/extension/test.sh
+++ b/test/extension/test.sh
@@ -588,8 +588,7 @@ test_extension|public|"local-table-with-dashes"'
 
     # Check CDB_Get_Foreign_Updated_At is robust to unimported CDB_TableMetadata
     sql postgres "DROP FOREIGN TABLE IF EXISTS test_fdw.cdb_tablemetadata;"
-    sql postgres "SELECT cartodb.CDB_Get_Foreign_Updated_At('test_fdw.foo') < (now() + interval '1 minute')" should 't'
-    sql postgres "SELECT cartodb.CDB_Get_Foreign_Updated_At('test_fdw.foo') > (now() - interval '1 minute')" should 't'
+    sql postgres "SELECT cartodb.CDB_Get_Foreign_Updated_At('test_fdw.foo') IS NULL" should 't'
 
     # Teardown
     DATABASE=fdw_target sql postgres 'REVOKE USAGE ON SCHEMA test_fdw FROM fdw_user;'


### PR DESCRIPTION
This may happen with non-carto DB's, when checking the updated_at
times and not finding the corresponding remote.cdb_tablemetadata
imported from the foreign non-carto DB.

Instead of failing, return a NOW() timestampt, so that caching logic
just assumes there may have been changes.

This makes it work today, and leaves open the possibility of adding
the required carto metadata for homogeneous caching in the future.

With this I can use the Maps API against a non-carto foreign table, without needing any other patches.