### PR TITLE
User defined FDW's

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ before_install:
   - sudo apt-get install -y --allow-unauthenticated postgresql-$POSTGRESQL_VERSION-postgis-$POSTGIS_VERSION postgresql-$POSTGRESQL_VERSION-postgis-$POSTGIS_VERSION-scripts postgis postgresql-plpython-$POSTGRESQL_VERSION
   - sudo pg_dropcluster --stop $POSTGRESQL_VERSION main
   - sudo rm -rf /etc/postgresql/$POSTGRESQL_VERSION /var/lib/postgresql/$POSTGRESQL_VERSION
-  - sudo pg_createcluster -u postgres $POSTGRESQL_VERSION main -- -A trust
+  - sudo pg_createcluster -u postgres $POSTGRESQL_VERSION main -- --auth-local trust --auth-host password
   - sudo /etc/init.d/postgresql start $POSTGRESQL_VERSION || sudo journalctl -xe
   - sudo pip install redis==2.4.9
 script:

--- a/scripts-available/CDB_ForeignTable.sql
+++ b/scripts-available/CDB_ForeignTable.sql
@@ -150,8 +150,10 @@ LANGUAGE plpgsql VOLATILE PARALLEL UNSAFE;
 --      "host": "myhostname.us-east-2.rds.amazonaws.com",
 --      "port": "5432"
 --    },
---    "user": "fdw_user",
---    "password": "secret"
+--    "user_mapping": {
+--      "user": "fdw_user",
+--      "password": "secret"
+--    }
 -- ');
 --
 -- Underneath it will:
@@ -169,8 +171,71 @@ LANGUAGE plpgsql VOLATILE PARALLEL UNSAFE;
 --   * The publicuser: GRANT amazon TO publicuser;
 CREATE OR REPLACE FUNCTION @extschema@.CDB_SetUp_Foreign_Server(fdw_name NAME, config json)
 RETURNS void AS $$
--- TODO Code here
-$$ LANGUAGE SQL VOLATILE PARALLEL UNSAFE;
+DECLARE
+  row record;
+  option record;
+BEGIN
+  -- TODO: refactor with original function
+  -- This function tries to be as idempotent as possible, by not creating anything more than once
+  -- (not even using IF NOT EXIST to avoid throwing warnings)
+  IF NOT EXISTS ( SELECT * FROM pg_extension WHERE extname = 'postgres_fdw') THEN
+    CREATE EXTENSION postgres_fdw;
+  END IF;
+  -- Create FDW first if it does not exist
+  IF NOT EXISTS ( SELECT * FROM pg_foreign_server WHERE srvname = fdw_name)
+    THEN
+    EXECUTE FORMAT('CREATE SERVER %I FOREIGN DATA WRAPPER postgres_fdw', fdw_name);
+  END IF;
+
+  -- Set FDW settings
+  FOR row IN SELECT p.key, p.value from lateral json_each_text(config->'server') p
+    LOOP
+      IF NOT EXISTS (WITH a AS (select split_part(unnest(srvoptions), '=', 1) as options from pg_foreign_server where srvname=fdw_name) SELECT * from a where options = row.key)
+        THEN
+        EXECUTE FORMAT('ALTER SERVER %I OPTIONS (ADD %I %L)', fdw_name, row.key, row.value);
+      ELSE
+        EXECUTE FORMAT('ALTER SERVER %I OPTIONS (SET %I %L)', fdw_name, row.key, row.value);
+      END IF;
+    END LOOP;
+
+    -- Create specific role for this
+    IF NOT EXISTS ( SELECT 1 FROM pg_roles WHERE rolname = fdw_name) THEN
+       EXECUTE format('CREATE ROLE %I NOLOGIN', fdw_name);
+    END IF;
+
+    -- Create user mapping
+    IF NOT EXISTS ( SELECT * FROM pg_user_mappings WHERE srvname = fdw_name AND usename = fdw_name ) THEN
+        EXECUTE FORMAT ('CREATE USER MAPPING FOR %I SERVER %I', fdw_name, fdw_name);
+    END IF;
+
+    -- Update user mapping settings
+    FOR option IN SELECT o.key, o.value from lateral json_each_text('user_mapping') o LOOP
+        IF NOT EXISTS (WITH a AS (select split_part(unnest(umoptions), '=', 1) as options from pg_user_mappings WHERE srvname = fdw_name AND usename = fdw_name) SELECT * from a where options = option.key) THEN
+          EXECUTE FORMAT('ALTER USER MAPPING FOR %I SERVER %I OPTIONS (ADD %I %L)', fdw_name, fdw_name, option.key, option.value);
+        ELSE
+          EXECUTE FORMAT('ALTER USER MAPPING FOR %I SERVER %I OPTIONS (SET %I %L)', fdw_name, fdw_name, option.key, option.value);
+        END IF;
+      END LOOP;
+    END LOOP;
+
+    -- Grant usage on the wrapper and server to the fdw role
+    EXECUTE FORMAT ('GRANT USAGE ON FOREIGN DATA WRAPPER postgres_fdw TO %I', fdw_name);
+    EXECUTE FORMAT ('GRANT USAGE ON FOREIGN ON FOREIGN SERVER %I TO %I', fdw_name, fdw_name);
+
+    -- Create schema if it does not exist.
+    IF NOT EXISTS ( SELECT * from pg_namespace WHERE nspname=fdw_name) THEN
+      EXECUTE FORMAT ('CREATE SCHEMA %I', fdw_name);
+    END IF;
+
+    -- Give the fdw role usage permisions over the schema
+    EXECUTE FORMAT ('GRANT USAGE ON SCHEMA %I TO %I', fdw_name, fdw_name);
+
+    -- Grant the fdw role to the caller, and permissions to grant it to others
+    EXECUTE FORMAT ('GRANT %I TO %I WITH ADMIN OPTION', fdw_name, session_user);
+
+    -- TODO: Bring here the remote cdb_tablemetadata
+
+$$ LANGUAGE plpgsql VOLATILE PARALLEL UNSAFE SECURITY DEFINER;
 
 CREATE OR REPLACE FUNCTION @extschema@._cdb_dbname_of_foreign_table(reloid oid)
 RETURNS TEXT AS $$

--- a/scripts-available/CDB_ForeignTable.sql
+++ b/scripts-available/CDB_ForeignTable.sql
@@ -215,7 +215,6 @@ BEGIN
         ELSE
           EXECUTE FORMAT('ALTER USER MAPPING FOR %I SERVER %I OPTIONS (SET %I %L)', fdw_name, fdw_name, option.key, option.value);
         END IF;
-      END LOOP;
     END LOOP;
 
     -- Grant usage on the wrapper and server to the fdw role
@@ -234,7 +233,7 @@ BEGIN
     EXECUTE FORMAT ('GRANT %I TO %I WITH ADMIN OPTION', fdw_name, session_user);
 
     -- TODO: Bring here the remote cdb_tablemetadata
-
+END
 $$ LANGUAGE plpgsql VOLATILE PARALLEL UNSAFE SECURITY DEFINER;
 
 CREATE OR REPLACE FUNCTION @extschema@._cdb_dbname_of_foreign_table(reloid oid)

--- a/scripts-available/CDB_ForeignTable.sql
+++ b/scripts-available/CDB_ForeignTable.sql
@@ -241,14 +241,24 @@ BEGIN
 END
 $$ LANGUAGE plpgsql VOLATILE PARALLEL UNSAFE SECURITY DEFINER;
 
+
+-- A function to drop a user-defined foreign server and all related objects
+-- It does not read from CDB_Conf
+--
+-- Sample call:
+--   SELECT cartodb.CDB_Drop_User_Foreign_Server('amazon')
+--
+-- Note: if there's any dependent object (i.e. foreign table) this call will fail
 CREATE OR REPLACE FUNCTION @extschema@.CDB_Drop_User_Foreign_Server(fdw_name NAME)
 RETURNS void AS $$
 BEGIN
     EXECUTE FORMAT ('DROP SCHEMA %I', fdw_name);
     EXECUTE FORMAT ('DROP USER MAPPING FOR public SERVER %I', fdw_name);
     EXECUTE FORMAT ('DROP SERVER %I', fdw_name);
+    EXECUTE FORMAT ('REVOKE USAGE ON FOREIGN DATA WRAPPER postgres_fdw FROM %I', fdw_name);
+    EXECUTE FORMAT ('DROP ROLE %I', fdw_name);
 END
-$$ LANGUAGE plpgsql VOLATILE PARALLEL UNSAFE;
+$$ LANGUAGE plpgsql VOLATILE PARALLEL UNSAFE SECURITY DEFINER;
 
 
 -- Set up a user foreign table

--- a/scripts-available/CDB_ForeignTable.sql
+++ b/scripts-available/CDB_ForeignTable.sql
@@ -203,6 +203,9 @@ BEGIN
        EXECUTE format('CREATE ROLE %I NOLOGIN', fdw_name);
     END IF;
 
+    -- Transfer ownership of the server to the fdw role
+    EXECUTE format('ALTER SERVER %I OWNER TO %I', fdw_name, fdw_name);
+
     -- Create user mapping
     IF NOT EXISTS ( SELECT * FROM pg_user_mappings WHERE srvname = fdw_name AND usename = fdw_name ) THEN
         EXECUTE FORMAT ('CREATE USER MAPPING FOR %I SERVER %I', fdw_name, fdw_name);
@@ -226,8 +229,8 @@ BEGIN
       EXECUTE FORMAT ('CREATE SCHEMA %I', fdw_name);
     END IF;
 
-    -- Give the fdw role usage permisions over the schema
-    EXECUTE FORMAT ('GRANT USAGE ON SCHEMA %I TO %I', fdw_name, fdw_name);
+    -- Give the fdw role ownership over the schema
+    EXECUTE FORMAT ('ALTER SCHEMA %I OWNER TO %I', fdw_name, fdw_name);
 
     -- Grant the fdw role to the caller, and permissions to grant it to others
     EXECUTE FORMAT ('GRANT %I TO %I WITH ADMIN OPTION', fdw_name, session_user);

--- a/scripts-available/CDB_ForeignTable.sql
+++ b/scripts-available/CDB_ForeignTable.sql
@@ -143,7 +143,7 @@ LANGUAGE plpgsql VOLATILE PARALLEL UNSAFE;
 -- It does not read from CDB_Conf
 --
 -- Sample call:
--- SELECT cartodb.CDB_SetUp_User_Foreign_Server('amazon', '{
+-- SELECT cartodb.CDB_SetUp_User_PG_FDW_Server('amazon', '{
 --    "server": {
 --      "extensions": "postgis",
 --      "dbname": "testdb",
@@ -169,7 +169,7 @@ LANGUAGE plpgsql VOLATILE PARALLEL UNSAFE;
 --   * Specific roles: GRANT amazon TO role_name;
 --   * Members of the organization: SELECT cartodb.CDB_Organization_Grant_Role('amazon');
 --   * The publicuser: GRANT amazon TO publicuser;
-CREATE OR REPLACE FUNCTION @extschema@.CDB_SetUp_User_Foreign_Server(fdw_name NAME, config json)
+CREATE OR REPLACE FUNCTION @extschema@.CDB_SetUp_User_PG_FDW_Server(fdw_name NAME, config json)
 RETURNS void AS $$
 DECLARE
   row record;
@@ -246,10 +246,10 @@ $$ LANGUAGE plpgsql VOLATILE PARALLEL UNSAFE SECURITY DEFINER;
 -- It does not read from CDB_Conf
 --
 -- Sample call:
---   SELECT cartodb.CDB_Drop_User_Foreign_Server('amazon')
+--   SELECT cartodb.CDB_Drop_User_PG_FDW_Server('amazon')
 --
 -- Note: if there's any dependent object (i.e. foreign table) this call will fail
-CREATE OR REPLACE FUNCTION @extschema@.CDB_Drop_User_Foreign_Server(fdw_name NAME)
+CREATE OR REPLACE FUNCTION @extschema@.CDB_Drop_User_PG_FDW_Server(fdw_name NAME)
 RETURNS void AS $$
 BEGIN
     EXECUTE FORMAT ('DROP SCHEMA %I', fdw_name);
@@ -263,9 +263,9 @@ $$ LANGUAGE plpgsql VOLATILE PARALLEL UNSAFE SECURITY DEFINER;
 
 -- Set up a user foreign table
 -- E.g:
---   SELECT cartodb.CDB_SetUp_User_Foreign_Table('amazon', 'carto_lite', 'mytable');
+--   SELECT cartodb.CDB_SetUp_User_PG_FDW_Table('amazon', 'carto_lite', 'mytable');
 --   SELECT * FROM amazon.my_table;
-CREATE OR REPLACE FUNCTION @extschema@.CDB_SetUp_User_Foreign_Table(fdw_name NAME, foreign_schema NAME, table_name NAME)
+CREATE OR REPLACE FUNCTION @extschema@.CDB_SetUp_User_PG_FDW_Table(fdw_name NAME, foreign_schema NAME, table_name NAME)
 RETURNS void AS $$
 BEGIN
   EXECUTE FORMAT ('IMPORT FOREIGN SCHEMA %I LIMIT TO (%I) FROM SERVER %I INTO %I;', foreign_schema, table_name, fdw_name, fdw_name);

--- a/scripts-available/CDB_ForeignTable.sql
+++ b/scripts-available/CDB_ForeignTable.sql
@@ -170,7 +170,7 @@ LANGUAGE plpgsql VOLATILE PARALLEL UNSAFE;
 --   * Specific roles: GRANT amazon TO role_name;
 --   * Members of the organization: SELECT cartodb.CDB_Organization_Grant_Role('amazon');
 --   * The publicuser: GRANT amazon TO publicuser;
-CREATE OR REPLACE FUNCTION @extschema@.CDB_SetUp_User_PG_FDW_Server(fdw_name NAME, config json)
+CREATE OR REPLACE FUNCTION @extschema@._CDB_SetUp_User_PG_FDW_Server(fdw_name NAME, config json)
 RETURNS void AS $$
 DECLARE
   row record;
@@ -248,7 +248,7 @@ $$ LANGUAGE plpgsql VOLATILE PARALLEL UNSAFE;
 --   SELECT cartodb.CDB_Drop_User_PG_FDW_Server('amazon')
 --
 -- Note: if there's any dependent object (i.e. foreign table) this call will fail
-CREATE OR REPLACE FUNCTION @extschema@.CDB_Drop_User_PG_FDW_Server(fdw_name NAME)
+CREATE OR REPLACE FUNCTION @extschema@._CDB_Drop_User_PG_FDW_Server(fdw_name NAME)
 RETURNS void AS $$
 BEGIN
     EXECUTE FORMAT ('DROP SCHEMA %I', fdw_name);

--- a/scripts-available/CDB_ForeignTable.sql
+++ b/scripts-available/CDB_ForeignTable.sql
@@ -241,6 +241,17 @@ BEGIN
 END
 $$ LANGUAGE plpgsql VOLATILE PARALLEL UNSAFE SECURITY DEFINER;
 
+
+CREATE OR REPLACE FUNCTION @extschema@.CDB_SetUp_User_Foreign_Table(fdw_name NAME, table_name NAME)
+RETURNS void AS $$
+BEGIN
+  EXECUTE FORMAT ('IMPORT FOREIGN SCHEMA carto_lite LIMIT TO (%I) FROM SERVER %I INTO %I;', table_name, fdw_name, fdw_name);
+  --- Grant SELECT to fdw role
+  EXECUTE FORMAT ('GRANT SELECT ON %I.%I TO %I;', fdw_name, table_name, fdw_name);
+END
+$$ LANGUAGE plpgsql VOLATILE PARALLEL UNSAFE;
+
+
 CREATE OR REPLACE FUNCTION @extschema@._cdb_dbname_of_foreign_table(reloid oid)
 RETURNS TEXT AS $$
     SELECT option_value FROM pg_options_to_table((

--- a/scripts-available/CDB_ForeignTable.sql
+++ b/scripts-available/CDB_ForeignTable.sql
@@ -242,10 +242,14 @@ END
 $$ LANGUAGE plpgsql VOLATILE PARALLEL UNSAFE SECURITY DEFINER;
 
 
-CREATE OR REPLACE FUNCTION @extschema@.CDB_SetUp_User_Foreign_Table(fdw_name NAME, table_name NAME)
+-- Set up a user foreign table
+-- E.g:
+--   SELECT cartodb.CDB_SetUp_User_Foreign_Table('amazon', 'carto_lite', 'mytable');
+--   SELECT * FROM amazon.my_table;
+CREATE OR REPLACE FUNCTION @extschema@.CDB_SetUp_User_Foreign_Table(fdw_name NAME, foreign_schema NAME, table_name NAME)
 RETURNS void AS $$
 BEGIN
-  EXECUTE FORMAT ('IMPORT FOREIGN SCHEMA carto_lite LIMIT TO (%I) FROM SERVER %I INTO %I;', table_name, fdw_name, fdw_name);
+  EXECUTE FORMAT ('IMPORT FOREIGN SCHEMA %I LIMIT TO (%I) FROM SERVER %I INTO %I;', foreign_schema, table_name, fdw_name, fdw_name);
   --- Grant SELECT to fdw role
   EXECUTE FORMAT ('GRANT SELECT ON %I.%I TO %I;', fdw_name, table_name, fdw_name);
 END

--- a/scripts-available/CDB_ForeignTable.sql
+++ b/scripts-available/CDB_ForeignTable.sql
@@ -167,7 +167,7 @@ LANGUAGE plpgsql VOLATILE PARALLEL UNSAFE;
 -- It is the responsibility of the caller to grant that role to either:
 --   * Nobody
 --   * Specific roles: GRANT amazon TO role_name;
---   * Members of the organization: SELECT cartodb.CDB_Grant_Role_To_Org_Members('amazon'); TODO
+--   * Members of the organization: SELECT cartodb.CDB_Organization_Grant_Role('amazon');
 --   * The publicuser: GRANT amazon TO publicuser;
 CREATE OR REPLACE FUNCTION @extschema@.CDB_SetUp_User_Foreign_Server(fdw_name NAME, config json)
 RETURNS void AS $$

--- a/scripts-available/CDB_ForeignTable.sql
+++ b/scripts-available/CDB_ForeignTable.sql
@@ -191,11 +191,13 @@ BEGIN
   -- (not even using IF NOT EXIST to avoid throwing warnings)
   IF NOT EXISTS ( SELECT * FROM pg_extension WHERE extname = 'postgres_fdw') THEN
     CREATE EXTENSION postgres_fdw;
+    RAISE NOTICE 'Created postgres_fdw extension';
   END IF;
   -- Create FDW first if it does not exist
   IF NOT EXISTS ( SELECT * FROM pg_foreign_server WHERE srvname = fdw_objects_name)
     THEN
     EXECUTE FORMAT('CREATE SERVER %I FOREIGN DATA WRAPPER postgres_fdw', fdw_objects_name);
+    RAISE NOTICE 'Created server % using postgres_fdw', fdw_objects_name;
   END IF;
 
   -- Set FDW settings
@@ -212,6 +214,7 @@ BEGIN
     -- Create specific role for this
     IF NOT EXISTS ( SELECT 1 FROM pg_roles WHERE rolname = fdw_objects_name) THEN
        EXECUTE format('CREATE ROLE %I NOLOGIN', fdw_objects_name);
+       RAISE NOTICE 'Created special role % to access the correponding FDW', fdw_objects_name;
     END IF;
 
     -- Transfer ownership of the server to the fdw role
@@ -222,6 +225,7 @@ BEGIN
     -- so that we don't need to create a mapping for every user nor store credentials elsewhere
     IF NOT EXISTS ( SELECT * FROM pg_user_mappings WHERE srvname = fdw_objects_name AND usename = 'public' ) THEN
         EXECUTE FORMAT ('CREATE USER MAPPING FOR public SERVER %I', fdw_objects_name);
+        RAISE NOTICE 'Created user mapping for accesing foreign server %', fdw_objects_name;
     END IF;
 
     -- Update user mapping settings
@@ -235,15 +239,19 @@ BEGIN
 
     -- Grant usage on the wrapper and server to the fdw role
     EXECUTE FORMAT ('GRANT USAGE ON FOREIGN DATA WRAPPER postgres_fdw TO %I', fdw_objects_name);
+    RAISE NOTICE 'Granted usage on the postgres_fdw to the role %', fdw_objects_name;
     EXECUTE FORMAT ('GRANT USAGE ON FOREIGN SERVER %I TO %I', fdw_objects_name, fdw_objects_name);
+    RAISE NOTICE 'Granted usage on the foreign server to the role %', fdw_objects_name;
 
     -- Create schema if it does not exist.
     IF NOT EXISTS ( SELECT * from pg_namespace WHERE nspname=fdw_objects_name) THEN
       EXECUTE FORMAT ('CREATE SCHEMA %I', fdw_objects_name);
+      RAISE NOTICE 'Created schema % to host foreign tables', fdw_objects_name;
     END IF;
 
     -- Give the fdw role ownership over the schema
     EXECUTE FORMAT ('ALTER SCHEMA %I OWNER TO %I', fdw_objects_name, fdw_objects_name);
+    RAISE NOTICE 'Gave ownership on the schema % to %', fdw_objects_name, fdw_objects_name;
 
     -- TODO: Bring here the remote cdb_tablemetadata
 END
@@ -264,10 +272,15 @@ DECLARE
     fdw_objects_name NAME := @extschema@.__CDB_User_FDW_Object_Names(fdw_input_name);
 BEGIN
     EXECUTE FORMAT ('DROP SCHEMA %I', fdw_objects_name);
+    RAISE NOTICE 'Dropped schema %', fdw_objects_name;
     EXECUTE FORMAT ('DROP USER MAPPING FOR public SERVER %I', fdw_objects_name);
+    RAISE NOTICE 'Dropped user mapping for server %', fdw_objects_name;
     EXECUTE FORMAT ('DROP SERVER %I', fdw_objects_name);
+    RAISE NOTICE 'Dropped foreign server %', fdw_objects_name;
     EXECUTE FORMAT ('REVOKE USAGE ON FOREIGN DATA WRAPPER postgres_fdw FROM %I', fdw_objects_name);
+    RAISE NOTICE 'Revoked usage on postgres_fdw from %', fdw_objects_name;
     EXECUTE FORMAT ('DROP ROLE %I', fdw_objects_name);
+    RAISE NOTICE 'Dropped role %', fdw_objects_name;
 END
 $$ LANGUAGE plpgsql VOLATILE PARALLEL UNSAFE;
 

--- a/scripts-available/CDB_ForeignTable.sql
+++ b/scripts-available/CDB_ForeignTable.sql
@@ -219,7 +219,7 @@ BEGIN
 
     -- Grant usage on the wrapper and server to the fdw role
     EXECUTE FORMAT ('GRANT USAGE ON FOREIGN DATA WRAPPER postgres_fdw TO %I', fdw_name);
-    EXECUTE FORMAT ('GRANT USAGE ON FOREIGN ON FOREIGN SERVER %I TO %I', fdw_name, fdw_name);
+    EXECUTE FORMAT ('GRANT USAGE ON FOREIGN SERVER %I TO %I', fdw_name, fdw_name);
 
     -- Create schema if it does not exist.
     IF NOT EXISTS ( SELECT * from pg_namespace WHERE nspname=fdw_name) THEN

--- a/scripts-available/CDB_ForeignTable.sql
+++ b/scripts-available/CDB_ForeignTable.sql
@@ -154,7 +154,7 @@ LANGUAGE plpgsql VOLATILE PARALLEL UNSAFE;
 --      "user": "fdw_user",
 --      "password": "secret"
 --    }
--- ');
+-- }');
 --
 -- Underneath it will:
 --   * Set up postgresql_fdw

--- a/scripts-available/CDB_ForeignTable.sql
+++ b/scripts-available/CDB_ForeignTable.sql
@@ -140,7 +140,8 @@ LANGUAGE plpgsql VOLATILE PARALLEL UNSAFE;
 
 
 -- A function to set up a user-defined foreign data server
--- It does not read from CDB_Conf
+-- It does not read from CDB_Conf.
+-- Only superuser roles can invoke it successfully
 --
 -- Sample call:
 -- SELECT cartodb.CDB_SetUp_User_PG_FDW_Server('amazon', '{
@@ -164,7 +165,7 @@ LANGUAGE plpgsql VOLATILE PARALLEL UNSAFE;
 --   * Create a schema 'amazon' as a convenience to set up all foreign
 --     tables over there
 --
--- It is the responsibility of the caller to grant that role to either:
+-- It is the responsibility of the superuser to grant that role to either:
 --   * Nobody
 --   * Specific roles: GRANT amazon TO role_name;
 --   * Members of the organization: SELECT cartodb.CDB_Organization_Grant_Role('amazon');
@@ -234,16 +235,14 @@ BEGIN
     -- Give the fdw role ownership over the schema
     EXECUTE FORMAT ('ALTER SCHEMA %I OWNER TO %I', fdw_name, fdw_name);
 
-    -- Grant the fdw role to the caller, and permissions to grant it to others
-    EXECUTE FORMAT ('GRANT %I TO %I WITH ADMIN OPTION', fdw_name, session_user);
-
     -- TODO: Bring here the remote cdb_tablemetadata
 END
-$$ LANGUAGE plpgsql VOLATILE PARALLEL UNSAFE SECURITY DEFINER;
+$$ LANGUAGE plpgsql VOLATILE PARALLEL UNSAFE;
 
 
 -- A function to drop a user-defined foreign server and all related objects
 -- It does not read from CDB_Conf
+-- It must be executed with a superuser role to succeed
 --
 -- Sample call:
 --   SELECT cartodb.CDB_Drop_User_PG_FDW_Server('amazon')
@@ -258,7 +257,7 @@ BEGIN
     EXECUTE FORMAT ('REVOKE USAGE ON FOREIGN DATA WRAPPER postgres_fdw FROM %I', fdw_name);
     EXECUTE FORMAT ('DROP ROLE %I', fdw_name);
 END
-$$ LANGUAGE plpgsql VOLATILE PARALLEL UNSAFE SECURITY DEFINER;
+$$ LANGUAGE plpgsql VOLATILE PARALLEL UNSAFE;
 
 
 -- Set up a user foreign table

--- a/scripts-available/CDB_ForeignTable.sql
+++ b/scripts-available/CDB_ForeignTable.sql
@@ -209,7 +209,7 @@ BEGIN
     END IF;
 
     -- Update user mapping settings
-    FOR option IN SELECT o.key, o.value from lateral json_each_text('user_mapping') o LOOP
+    FOR option IN SELECT o.key, o.value from lateral json_each_text(config->'user_mapping') o LOOP
         IF NOT EXISTS (WITH a AS (select split_part(unnest(umoptions), '=', 1) as options from pg_user_mappings WHERE srvname = fdw_name AND usename = fdw_name) SELECT * from a where options = option.key) THEN
           EXECUTE FORMAT('ALTER USER MAPPING FOR %I SERVER %I OPTIONS (ADD %I %L)', fdw_name, fdw_name, option.key, option.value);
         ELSE

--- a/scripts-available/CDB_ForeignTable.sql
+++ b/scripts-available/CDB_ForeignTable.sql
@@ -139,6 +139,39 @@ $$
 LANGUAGE plpgsql VOLATILE PARALLEL UNSAFE;
 
 
+-- A function to set up a user-defined foreign data server
+-- It does not read from CDB_Conf
+--
+-- Sample call:
+-- SELECT cartodb.CDB_SetUp_Foreign_Server('amazon', '{
+--    "server": {
+--      "extensions": "postgis",
+--      "dbname": "testdb",
+--      "host": "myhostname.us-east-2.rds.amazonaws.com",
+--      "port": "5432"
+--    },
+--    "user": "fdw_user",
+--    "password": "secret"
+-- ');
+--
+-- Underneath it will:
+--   * Set up postgresql_fdw
+--   * Create a server with the name 'amazon'
+--   * Create a role called 'amazon' to manage access
+--   * Create a user mapping with that role 'amazon'
+--   * Create a schema 'amazon' as a convenience to set up all foreign
+--     tables over there
+--
+-- It is the responsibility of the caller to grant that role to either:
+--   * Nobody
+--   * Specific roles: GRANT amazon TO role_name;
+--   * Members of the organization: SELECT cartodb.CDB_Grant_Role_To_Org_Members('amazon'); TODO
+--   * The publicuser: GRANT amazon TO publicuser;
+CREATE OR REPLACE FUNCTION @extschema@.CDB_SetUp_Foreign_Server(fdw_name NAME, config json)
+RETURNS void AS $$
+-- TODO Code here
+$$ LANGUAGE SQL VOLATILE PARALLEL UNSAFE;
+
 CREATE OR REPLACE FUNCTION @extschema@._cdb_dbname_of_foreign_table(reloid oid)
 RETURNS TEXT AS $$
     SELECT option_value FROM pg_options_to_table((

--- a/scripts-available/CDB_ForeignTable.sql
+++ b/scripts-available/CDB_ForeignTable.sql
@@ -143,7 +143,7 @@ LANGUAGE plpgsql VOLATILE PARALLEL UNSAFE;
 -- It does not read from CDB_Conf
 --
 -- Sample call:
--- SELECT cartodb.CDB_SetUp_Foreign_Server('amazon', '{
+-- SELECT cartodb.CDB_SetUp_User_Foreign_Server('amazon', '{
 --    "server": {
 --      "extensions": "postgis",
 --      "dbname": "testdb",
@@ -169,7 +169,7 @@ LANGUAGE plpgsql VOLATILE PARALLEL UNSAFE;
 --   * Specific roles: GRANT amazon TO role_name;
 --   * Members of the organization: SELECT cartodb.CDB_Grant_Role_To_Org_Members('amazon'); TODO
 --   * The publicuser: GRANT amazon TO publicuser;
-CREATE OR REPLACE FUNCTION @extschema@.CDB_SetUp_Foreign_Server(fdw_name NAME, config json)
+CREATE OR REPLACE FUNCTION @extschema@.CDB_SetUp_User_Foreign_Server(fdw_name NAME, config json)
 RETURNS void AS $$
 DECLARE
   row record;

--- a/scripts-available/CDB_ForeignTable.sql
+++ b/scripts-available/CDB_ForeignTable.sql
@@ -241,6 +241,15 @@ BEGIN
 END
 $$ LANGUAGE plpgsql VOLATILE PARALLEL UNSAFE SECURITY DEFINER;
 
+CREATE OR REPLACE FUNCTION @extschema@.CDB_Drop_User_Foreign_Server(fdw_name NAME)
+RETURNS void AS $$
+BEGIN
+    EXECUTE FORMAT ('DROP SCHEMA %I', fdw_name);
+    EXECUTE FORMAT ('DROP USER MAPPING FOR public SERVER %I', fdw_name);
+    EXECUTE FORMAT ('DROP SERVER %I', fdw_name);
+END
+$$ LANGUAGE plpgsql VOLATILE PARALLEL UNSAFE;
+
 
 -- Set up a user foreign table
 -- E.g:

--- a/scripts-available/CDB_Organizations.sql
+++ b/scripts-available/CDB_Organizations.sql
@@ -169,3 +169,30 @@ BEGIN
     EXECUTE 'SELECT @extschema@.CDB_Organization_Remove_Access_Permission(''' || from_schema || ''', ''' || table_name || ''', ''' || @extschema@.CDB_Organization_Member_Group_Role_Member_Name() || ''');';
 END
 $$ LANGUAGE PLPGSQL VOLATILE PARALLEL UNSAFE;
+
+
+--------------------------------------------------------------------------------
+-- Role management
+--------------------------------------------------------------------------------
+CREATE OR REPLACE
+FUNCTION @extschema@.CDB_Organization_Grant_Role(role_name name)
+RETURNS VOID AS $$
+DECLARE
+    org_role TEXT;
+BEGIN
+    org_role := @extschema@.CDB_Organization_Member_Group_Role_Member_Name();
+    EXECUTE format('GRANT %I TO %I', role_name, org_role);
+END
+$$ LANGUAGE PLPGSQL VOLATILE PARALLEL UNSAFE;
+
+
+CREATE OR REPLACE
+FUNCTION @extschema@.CDB_Organization_Revoke_Role(role_name name)
+RETURNS VOID AS $$
+DECLARE
+    org_role TEXT;
+BEGIN
+    org_role := @extschema@.CDB_Organization_Member_Group_Role_Member_Name();
+    EXECUTE format('REVOKE %I FROM %I', role_name, org_role);
+END
+$$ LANGUAGE PLPGSQL VOLATILE PARALLEL UNSAFE;

--- a/test/CDB_OAuth.sql
+++ b/test/CDB_OAuth.sql
@@ -1,7 +1,9 @@
 -- Create user and enable OAuth event trigger
 \set QUIET on
 SET client_min_messages TO error;
+DROP ROLE IF EXISTS "creator_role";
 CREATE ROLE "creator_role" LOGIN;
+DROP ROLE IF EXISTS "ownership_role";
 CREATE ROLE "ownership_role" LOGIN;
 GRANT ALL ON SCHEMA cartodb TO "creator_role";
 SELECT CDB_Conf_SetConf('api_keys_creator_role', '{"username": "creator_role", "permissions":[]}');

--- a/test/extension/test.sh
+++ b/test/extension/test.sh
@@ -607,7 +607,7 @@ test_extension|public|"local-table-with-dashes"'
    }
 }
 EOF
-    sql postgres "SELECT cartodb.CDB_SetUp_User_PG_FDW_Server('test_user_fdw', '$ufdw_config');"
+    sql postgres "SELECT cartodb._CDB_SetUp_User_PG_FDW_Server('test_user_fdw', '$ufdw_config');"
 
     # Grant a user access to that FDW, and to grant to others
     sql postgres "GRANT test_user_fdw TO cdb_testmember_1 WITH ADMIN OPTION;"
@@ -641,9 +641,9 @@ EOF
     sql cdb_testmember_1 "REVOKE test_user_fdw FROM publicuser;"
 
     # If there are dependent objects, we cannot drop the foreign server
-    sql postgres "SELECT cartodb.CDB_Drop_User_PG_FDW_Server('test_user_fdw')" fails
+    sql postgres "SELECT cartodb._CDB_Drop_User_PG_FDW_Server('test_user_fdw')" fails
     sql cdb_testmember_1 "DROP FOREIGN TABLE test_user_fdw.foo;"
-    sql postgres "SELECT cartodb.CDB_Drop_User_PG_FDW_Server('test_user_fdw')"
+    sql postgres "SELECT cartodb._CDB_Drop_User_PG_FDW_Server('test_user_fdw')"
 
 
     # Teardown

--- a/test/extension/test.sh
+++ b/test/extension/test.sh
@@ -612,9 +612,14 @@ EOF
     # Set up a user foreign table
     sql cdb_testmember_1 "SELECT cartodb.CDB_SetUp_User_Foreign_Table('test_user_fdw', 'test_fdw', 'foo');"
 
-    # Check that the table can be accessed
+    # Check that the table can be accessed by the owner/creator
     sql cdb_testmember_1 "SELECT * from test_user_fdw.foo;"
     sql cdb_testmember_1 "SELECT a from test_user_fdw.foo LIMIT 1;" should 42
+
+    # Check that the table can be accessed by some other user by granting the role
+    sql cdb_testmember_1 "GRANT test_user_fdw TO cdb_testmember_2;"
+    sql cdb_testmember_2 "SELECT a from test_user_fdw.foo LIMIT 1;" should 42
+    sql cdb_testmember_1 "REVOKE test_user_fdw FROM cdb_testmember_2;"
 
 
     # Teardown

--- a/test/extension/test.sh
+++ b/test/extension/test.sh
@@ -607,43 +607,43 @@ test_extension|public|"local-table-with-dashes"'
    }
 }
 EOF
-    sql postgres "SELECT cartodb._CDB_SetUp_User_PG_FDW_Server('user_defined_test', '$ufdw_config');"
+    sql postgres "SELECT cartodb._CDB_SetUp_User_PG_FDW_Server('user-defined-test', '$ufdw_config');"
 
     # Grant a user access to that FDW, and to grant to others
-    sql postgres "GRANT cdb_fdw_user_defined_test TO cdb_testmember_1 WITH ADMIN OPTION;"
+    sql postgres 'GRANT "cdb_fdw_user-defined-test" TO cdb_testmember_1 WITH ADMIN OPTION;'
 
     # Set up a user foreign table
-    sql cdb_testmember_1 "SELECT cartodb.CDB_SetUp_User_PG_FDW_Table('user_defined_test', 'test_fdw', 'foo');"
+    sql cdb_testmember_1 "SELECT cartodb.CDB_SetUp_User_PG_FDW_Table('user-defined-test', 'test_fdw', 'foo');"
 
     # Check that the table can be accessed by the owner/creator
-    sql cdb_testmember_1 "SELECT * from cdb_fdw_user_defined_test.foo;"
-    sql cdb_testmember_1 "SELECT a from cdb_fdw_user_defined_test.foo LIMIT 1;" should 42
+    sql cdb_testmember_1 'SELECT * from "cdb_fdw_user-defined-test".foo;'
+    sql cdb_testmember_1 'SELECT a from "cdb_fdw_user-defined-test".foo LIMIT 1;' should 42
 
     # Check that a role with no permissions cannot use the FDW to access a remote table
-    sql cdb_testmember_2 "IMPORT FOREIGN SCHEMA test_fdw LIMIT TO (foo) FROM SERVER cdb_fdw_user_defined_test INTO public" fails
+    sql cdb_testmember_2 'IMPORT FOREIGN SCHEMA test_fdw LIMIT TO (foo) FROM SERVER "cdb_fdw_user-defined-test" INTO public' fails
 
     # Check that the table can be accessed by some other user by granting the role
-    sql cdb_testmember_2 "SELECT a from cdb_fdw_user_defined_test.foo LIMIT 1;" fails
-    sql cdb_testmember_1 "GRANT cdb_fdw_user_defined_test TO cdb_testmember_2;"
-    sql cdb_testmember_2 "SELECT a from cdb_fdw_user_defined_test.foo LIMIT 1;" should 42
-    sql cdb_testmember_1 "REVOKE cdb_fdw_user_defined_test FROM cdb_testmember_2;"
+    sql cdb_testmember_2 'SELECT a from "cdb_fdw_user-defined-test".foo LIMIT 1;' fails
+    sql cdb_testmember_1 'GRANT "cdb_fdw_user-defined-test" TO cdb_testmember_2;'
+    sql cdb_testmember_2 'SELECT a from "cdb_fdw_user-defined-test".foo LIMIT 1;' should 42
+    sql cdb_testmember_1 'REVOKE "cdb_fdw_user-defined-test" FROM cdb_testmember_2;'
 
     # Check that the table can be accessed by org members
-    sql cdb_testmember_2 "SELECT a from cdb_fdw_user_defined_test.foo LIMIT 1;" fails
-    sql cdb_testmember_1 "SELECT cartodb.CDB_Organization_Grant_Role('cdb_fdw_user_defined_test');"
-    sql cdb_testmember_2 "SELECT a from cdb_fdw_user_defined_test.foo LIMIT 1;" should 42
-    sql cdb_testmember_1 "SELECT cartodb.CDB_Organization_Revoke_Role('cdb_fdw_user_defined_test');"
+    sql cdb_testmember_2 'SELECT a from "cdb_fdw_user-defined-test".foo LIMIT 1;' fails
+    sql cdb_testmember_1 "SELECT cartodb.CDB_Organization_Grant_Role('cdb_fdw_user-defined-test');"
+    sql cdb_testmember_2 'SELECT a from "cdb_fdw_user-defined-test".foo LIMIT 1;' should 42
+    sql cdb_testmember_1 "SELECT cartodb.CDB_Organization_Revoke_Role('cdb_fdw_user-defined-test');"
 
     # By default publicuser cannot access the FDW
-    sql publicuser "SELECT a from cdb_fdw_user_defined_test.foo LIMIT 1;" fails
-    sql cdb_testmember_1 "GRANT cdb_fdw_user_defined_test TO publicuser;" # but can be granted
-    sql publicuser "SELECT a from cdb_fdw_user_defined_test.foo LIMIT 1;" should 42
-    sql cdb_testmember_1 "REVOKE cdb_fdw_user_defined_test FROM publicuser;"
+    sql publicuser 'SELECT a from "cdb_fdw_user-defined-test".foo LIMIT 1;' fails
+    sql cdb_testmember_1 'GRANT "cdb_fdw_user-defined-test" TO publicuser;' # but can be granted
+    sql publicuser 'SELECT a from "cdb_fdw_user-defined-test".foo LIMIT 1;' should 42
+    sql cdb_testmember_1 'REVOKE "cdb_fdw_user-defined-test" FROM publicuser;'
 
     # If there are dependent objects, we cannot drop the foreign server
-    sql postgres "SELECT cartodb._CDB_Drop_User_PG_FDW_Server('user_defined_test')" fails
-    sql cdb_testmember_1 "DROP FOREIGN TABLE cdb_fdw_user_defined_test.foo;"
-    sql postgres "SELECT cartodb._CDB_Drop_User_PG_FDW_Server('user_defined_test')"
+    sql postgres "SELECT cartodb._CDB_Drop_User_PG_FDW_Server('user-defined-test')" fails
+    sql cdb_testmember_1 'DROP FOREIGN TABLE "cdb_fdw_user-defined-test".foo;'
+    sql postgres "SELECT cartodb._CDB_Drop_User_PG_FDW_Server('user-defined-test')"
 
 
     # Teardown

--- a/test/extension/test.sh
+++ b/test/extension/test.sh
@@ -607,10 +607,10 @@ test_extension|public|"local-table-with-dashes"'
    }
 }
 EOF
-    sql cdb_testmember_1 "SELECT cartodb.CDB_SetUp_User_Foreign_Server('test_user_fdw', '$ufdw_config');"
+    sql cdb_testmember_1 "SELECT cartodb.CDB_SetUp_User_PG_FDW_Server('test_user_fdw', '$ufdw_config');"
 
     # Set up a user foreign table
-    sql cdb_testmember_1 "SELECT cartodb.CDB_SetUp_User_Foreign_Table('test_user_fdw', 'test_fdw', 'foo');"
+    sql cdb_testmember_1 "SELECT cartodb.CDB_SetUp_User_PG_FDW_Table('test_user_fdw', 'test_fdw', 'foo');"
 
     # Check that the table can be accessed by the owner/creator
     sql cdb_testmember_1 "SELECT * from test_user_fdw.foo;"
@@ -638,9 +638,9 @@ EOF
     sql cdb_testmember_1 "REVOKE test_user_fdw FROM publicuser;"
 
     # If there are dependent objects, we cannot drop the foreign server
-    sql cdb_testmember_1 "SELECT cartodb.CDB_Drop_User_Foreign_Server('test_user_fdw')" fails
+    sql cdb_testmember_1 "SELECT cartodb.CDB_Drop_User_PG_FDW_Server('test_user_fdw')" fails
     sql cdb_testmember_1 "DROP FOREIGN TABLE test_user_fdw.foo;"
-    sql cdb_testmember_1 "SELECT cartodb.CDB_Drop_User_Foreign_Server('test_user_fdw')"
+    sql cdb_testmember_1 "SELECT cartodb.CDB_Drop_User_PG_FDW_Server('test_user_fdw')"
 
 
     # Teardown

--- a/test/extension/test.sh
+++ b/test/extension/test.sh
@@ -621,6 +621,11 @@ EOF
     sql cdb_testmember_2 "SELECT a from test_user_fdw.foo LIMIT 1;" should 42
     sql cdb_testmember_1 "REVOKE test_user_fdw FROM cdb_testmember_2;"
 
+    # Check that the table can be accessed by org members
+    sql cdb_testmember_1 "SELECT cartodb.CDB_Organization_Grant_Role('test_user_fdw');"
+    sql cdb_testmember_2 "SELECT a from test_user_fdw.foo LIMIT 1;" should 42
+    sql cdb_testmember_1 "SELECT cartodb.CDB_Organization_Revoke_Role('test_user_fdw');"
+
 
     # Teardown
     DATABASE=fdw_target sql postgres 'REVOKE USAGE ON SCHEMA test_fdw FROM fdw_user;'

--- a/test/extension/test.sh
+++ b/test/extension/test.sh
@@ -607,43 +607,43 @@ test_extension|public|"local-table-with-dashes"'
    }
 }
 EOF
-    sql postgres "SELECT cartodb._CDB_SetUp_User_PG_FDW_Server('test_user_fdw', '$ufdw_config');"
+    sql postgres "SELECT cartodb._CDB_SetUp_User_PG_FDW_Server('user_defined_test', '$ufdw_config');"
 
     # Grant a user access to that FDW, and to grant to others
-    sql postgres "GRANT test_user_fdw TO cdb_testmember_1 WITH ADMIN OPTION;"
+    sql postgres "GRANT cdb_fdw_user_defined_test TO cdb_testmember_1 WITH ADMIN OPTION;"
 
     # Set up a user foreign table
-    sql cdb_testmember_1 "SELECT cartodb.CDB_SetUp_User_PG_FDW_Table('test_user_fdw', 'test_fdw', 'foo');"
+    sql cdb_testmember_1 "SELECT cartodb.CDB_SetUp_User_PG_FDW_Table('user_defined_test', 'test_fdw', 'foo');"
 
     # Check that the table can be accessed by the owner/creator
-    sql cdb_testmember_1 "SELECT * from test_user_fdw.foo;"
-    sql cdb_testmember_1 "SELECT a from test_user_fdw.foo LIMIT 1;" should 42
+    sql cdb_testmember_1 "SELECT * from cdb_fdw_user_defined_test.foo;"
+    sql cdb_testmember_1 "SELECT a from cdb_fdw_user_defined_test.foo LIMIT 1;" should 42
 
     # Check that a role with no permissions cannot use the FDW to access a remote table
-    sql cdb_testmember_2 "IMPORT FOREIGN SCHEMA test_fdw LIMIT TO (foo) FROM SERVER test_user_fdw INTO public" fails
+    sql cdb_testmember_2 "IMPORT FOREIGN SCHEMA test_fdw LIMIT TO (foo) FROM SERVER cdb_fdw_user_defined_test INTO public" fails
 
     # Check that the table can be accessed by some other user by granting the role
-    sql cdb_testmember_2 "SELECT a from test_user_fdw.foo LIMIT 1;" fails
-    sql cdb_testmember_1 "GRANT test_user_fdw TO cdb_testmember_2;"
-    sql cdb_testmember_2 "SELECT a from test_user_fdw.foo LIMIT 1;" should 42
-    sql cdb_testmember_1 "REVOKE test_user_fdw FROM cdb_testmember_2;"
+    sql cdb_testmember_2 "SELECT a from cdb_fdw_user_defined_test.foo LIMIT 1;" fails
+    sql cdb_testmember_1 "GRANT cdb_fdw_user_defined_test TO cdb_testmember_2;"
+    sql cdb_testmember_2 "SELECT a from cdb_fdw_user_defined_test.foo LIMIT 1;" should 42
+    sql cdb_testmember_1 "REVOKE cdb_fdw_user_defined_test FROM cdb_testmember_2;"
 
     # Check that the table can be accessed by org members
-    sql cdb_testmember_2 "SELECT a from test_user_fdw.foo LIMIT 1;" fails
-    sql cdb_testmember_1 "SELECT cartodb.CDB_Organization_Grant_Role('test_user_fdw');"
-    sql cdb_testmember_2 "SELECT a from test_user_fdw.foo LIMIT 1;" should 42
-    sql cdb_testmember_1 "SELECT cartodb.CDB_Organization_Revoke_Role('test_user_fdw');"
+    sql cdb_testmember_2 "SELECT a from cdb_fdw_user_defined_test.foo LIMIT 1;" fails
+    sql cdb_testmember_1 "SELECT cartodb.CDB_Organization_Grant_Role('cdb_fdw_user_defined_test');"
+    sql cdb_testmember_2 "SELECT a from cdb_fdw_user_defined_test.foo LIMIT 1;" should 42
+    sql cdb_testmember_1 "SELECT cartodb.CDB_Organization_Revoke_Role('cdb_fdw_user_defined_test');"
 
     # By default publicuser cannot access the FDW
-    sql publicuser "SELECT a from test_user_fdw.foo LIMIT 1;" fails
-    sql cdb_testmember_1 "GRANT test_user_fdw TO publicuser;" # but can be granted
-    sql publicuser "SELECT a from test_user_fdw.foo LIMIT 1;" should 42
-    sql cdb_testmember_1 "REVOKE test_user_fdw FROM publicuser;"
+    sql publicuser "SELECT a from cdb_fdw_user_defined_test.foo LIMIT 1;" fails
+    sql cdb_testmember_1 "GRANT cdb_fdw_user_defined_test TO publicuser;" # but can be granted
+    sql publicuser "SELECT a from cdb_fdw_user_defined_test.foo LIMIT 1;" should 42
+    sql cdb_testmember_1 "REVOKE cdb_fdw_user_defined_test FROM publicuser;"
 
     # If there are dependent objects, we cannot drop the foreign server
-    sql postgres "SELECT cartodb._CDB_Drop_User_PG_FDW_Server('test_user_fdw')" fails
-    sql cdb_testmember_1 "DROP FOREIGN TABLE test_user_fdw.foo;"
-    sql postgres "SELECT cartodb._CDB_Drop_User_PG_FDW_Server('test_user_fdw')"
+    sql postgres "SELECT cartodb._CDB_Drop_User_PG_FDW_Server('user_defined_test')" fails
+    sql cdb_testmember_1 "DROP FOREIGN TABLE cdb_fdw_user_defined_test.foo;"
+    sql postgres "SELECT cartodb._CDB_Drop_User_PG_FDW_Server('user_defined_test')"
 
 
     # Teardown

--- a/test/extension/test.sh
+++ b/test/extension/test.sh
@@ -607,14 +607,14 @@ test_extension|public|"local-table-with-dashes"'
    }
 }
 EOF
-    sql postgres "SELECT cartodb.CDB_SetUp_User_Foreign_Server('test_user_fdw', '$ufdw_config');"
+    sql cdb_testmember_1 "SELECT cartodb.CDB_SetUp_User_Foreign_Server('test_user_fdw', '$ufdw_config');"
 
     # Set up a user foreign table
-    sql postgres "SELECT cartodb.CDB_SetUp_User_Foreign_Table('test_user_fdw', 'test_fdw', 'foo');"
+    sql cdb_testmember_1 "SELECT cartodb.CDB_SetUp_User_Foreign_Table('test_user_fdw', 'test_fdw', 'foo');"
 
     # Check that the table can be accessed
-    sql postgres "SELECT * from test_user_fdw.foo;"
-    sql postgres "SELECT a from test_user_fdw.foo LIMIT 1;" should 42
+    sql cdb_testmember_1 "SELECT * from test_user_fdw.foo;"
+    sql cdb_testmember_1 "SELECT a from test_user_fdw.foo LIMIT 1;" should 42
 
 
     # Teardown
@@ -623,6 +623,12 @@ EOF
     DATABASE=fdw_target sql postgres 'REVOKE SELECT ON test_fdw.foo2 FROM fdw_user;'
     DATABASE=fdw_target sql postgres 'REVOKE SELECT ON cdb_tablemetadata_text FROM fdw_user;'
     DATABASE=fdw_target sql postgres 'DROP ROLE fdw_user;'
+
+    # TODO add to function to delete stuff
+    sql postgres 'DROP FOREIGN TABLE test_user_fdw.foo;'
+    sql postgres 'DROP schema test_user_fdw;'
+    sql postgres 'DROP USER MAPPING FOR public SERVER test_user_fdw;'
+    sql postgres 'DROP SERVER test_user_fdw;'
 
     sql postgres "select pg_terminate_backend(pid) from pg_stat_activity where datname='fdw_target';"
     DATABASE=fdw_target tear_down_database

--- a/test/extension/test.sh
+++ b/test/extension/test.sh
@@ -626,6 +626,9 @@ EOF
     sql cdb_testmember_2 "SELECT a from test_user_fdw.foo LIMIT 1;" should 42
     sql cdb_testmember_1 "SELECT cartodb.CDB_Organization_Revoke_Role('test_user_fdw');"
 
+    # If there are dependent objects, we cannot drop the foreign server
+    sql cdb_testmember_1 "SELECT cartodb.CDB_Drop_User_Foreign_Server('test_user_fdw')" fails
+
 
     # Teardown
     DATABASE=fdw_target sql postgres 'REVOKE USAGE ON SCHEMA test_fdw FROM fdw_user;'

--- a/test/extension/test.sh
+++ b/test/extension/test.sh
@@ -616,12 +616,17 @@ EOF
     sql cdb_testmember_1 "SELECT * from test_user_fdw.foo;"
     sql cdb_testmember_1 "SELECT a from test_user_fdw.foo LIMIT 1;" should 42
 
+    # Check that a role with no permissions cannot use the FDW to access a remote table
+    sql cdb_testmember_2 "IMPORT FOREIGN SCHEMA test_fdw LIMIT TO (foo) FROM SERVER test_user_fdw INTO public" fails
+
     # Check that the table can be accessed by some other user by granting the role
+    sql cdb_testmember_2 "SELECT a from test_user_fdw.foo LIMIT 1;" fails
     sql cdb_testmember_1 "GRANT test_user_fdw TO cdb_testmember_2;"
     sql cdb_testmember_2 "SELECT a from test_user_fdw.foo LIMIT 1;" should 42
     sql cdb_testmember_1 "REVOKE test_user_fdw FROM cdb_testmember_2;"
 
     # Check that the table can be accessed by org members
+    sql cdb_testmember_2 "SELECT a from test_user_fdw.foo LIMIT 1;" fails
     sql cdb_testmember_1 "SELECT cartodb.CDB_Organization_Grant_Role('test_user_fdw');"
     sql cdb_testmember_2 "SELECT a from test_user_fdw.foo LIMIT 1;" should 42
     sql cdb_testmember_1 "SELECT cartodb.CDB_Organization_Revoke_Role('test_user_fdw');"

--- a/test/extension/test.sh
+++ b/test/extension/test.sh
@@ -624,11 +624,8 @@ EOF
     DATABASE=fdw_target sql postgres 'REVOKE SELECT ON cdb_tablemetadata_text FROM fdw_user;'
     DATABASE=fdw_target sql postgres 'DROP ROLE fdw_user;'
 
-    # TODO add to function to delete stuff
-    sql postgres 'DROP FOREIGN TABLE test_user_fdw.foo;'
-    sql postgres 'DROP schema test_user_fdw;'
-    sql postgres 'DROP USER MAPPING FOR public SERVER test_user_fdw;'
-    sql postgres 'DROP SERVER test_user_fdw;'
+    sql cdb_testmember_1 "DROP FOREIGN TABLE test_user_fdw.foo;"
+    sql cdb_testmember_1 "SELECT cartodb.CDB_Drop_User_Foreign_Server('test_user_fdw')"
 
     sql postgres "select pg_terminate_backend(pid) from pg_stat_activity where datname='fdw_target';"
     DATABASE=fdw_target tear_down_database

--- a/test/extension/test.sh
+++ b/test/extension/test.sh
@@ -645,6 +645,12 @@ EOF
     sql cdb_testmember_1 'DROP FOREIGN TABLE "cdb_fdw_user-defined-test".foo;'
     sql postgres "SELECT cartodb._CDB_Drop_User_PG_FDW_Server('user-defined-test')"
 
+    # But if there are, we can set the force flag to true to drop everything (defaults to false)
+    sql postgres "SELECT cartodb._CDB_SetUp_User_PG_FDW_Server('another_user_defined_test', '$ufdw_config');"
+    sql postgres 'GRANT cdb_fdw_another_user_defined_test TO cdb_testmember_1 WITH ADMIN OPTION;'
+    sql cdb_testmember_1 "SELECT cartodb.CDB_SetUp_User_PG_FDW_Table('another_user_defined_test', 'test_fdw', 'foo');"
+    sql postgres "SELECT cartodb._CDB_Drop_User_PG_FDW_Server('another_user_defined_test', /* force = */ true)"
+
 
     # Teardown
     DATABASE=fdw_target sql postgres 'REVOKE USAGE ON SCHEMA test_fdw FROM fdw_user;'

--- a/test/extension/test.sh
+++ b/test/extension/test.sh
@@ -607,7 +607,10 @@ test_extension|public|"local-table-with-dashes"'
    }
 }
 EOF
-    sql cdb_testmember_1 "SELECT cartodb.CDB_SetUp_User_PG_FDW_Server('test_user_fdw', '$ufdw_config');"
+    sql postgres "SELECT cartodb.CDB_SetUp_User_PG_FDW_Server('test_user_fdw', '$ufdw_config');"
+
+    # Grant a user access to that FDW, and to grant to others
+    sql postgres "GRANT test_user_fdw TO cdb_testmember_1 WITH ADMIN OPTION;"
 
     # Set up a user foreign table
     sql cdb_testmember_1 "SELECT cartodb.CDB_SetUp_User_PG_FDW_Table('test_user_fdw', 'test_fdw', 'foo');"
@@ -638,9 +641,9 @@ EOF
     sql cdb_testmember_1 "REVOKE test_user_fdw FROM publicuser;"
 
     # If there are dependent objects, we cannot drop the foreign server
-    sql cdb_testmember_1 "SELECT cartodb.CDB_Drop_User_PG_FDW_Server('test_user_fdw')" fails
+    sql postgres "SELECT cartodb.CDB_Drop_User_PG_FDW_Server('test_user_fdw')" fails
     sql cdb_testmember_1 "DROP FOREIGN TABLE test_user_fdw.foo;"
-    sql cdb_testmember_1 "SELECT cartodb.CDB_Drop_User_PG_FDW_Server('test_user_fdw')"
+    sql postgres "SELECT cartodb.CDB_Drop_User_PG_FDW_Server('test_user_fdw')"
 
 
     # Teardown


### PR DESCRIPTION
This adds a couple of functions to ease set up of user foreign servers, mappings and tables.

Sample usage:
```sql
-- Create a FDW called "amazon"
SELECT cartodb.CDB_SetUp_User_Foreign_Server('amazon', '{
   "server": {
     "extensions": "postgis",
     "dbname": "testdb",
     "host": "localhost",
     "port": "5433"
   },
   "user_mapping": {
     "user": "fdw_user",
     "password": "secret"
   }
}');

-- Import a foreign table from "amazon"
SELECT cartodb.CDB_SetUp_User_Foreign_Table('amazon', 'carto-lite', 'cliwoc21');
```

NOTE: it is decoupled from carto-lite

It creates a role with the same name of the fdw (in the example, "amazon") and grants it to the caller of the function. So, by default just the caller can access the server, mappings and anything related to it, but they can also grant it to other users (including `publicuser`, the org role or even `public`).

E.g:

```sql
-- not the caller role
SELECT * FROM amazon.cliwoc21 limit 1;
ERROR:  permission denied for schema amazon
LINE 1: select * from amazon.cliwoc21 limit 1;

IMPORT FOREIGN SCHEMA carto_lite LIMIT TO (cliwoc21) FROM SERVER amazon INTO try_import;
ERROR:  permission denied for foreign server amazon
```

but we want to grant permissions to it:
```sql
GRANT amazon TO "development_cartodb_user_699ab2dc-dd77-4395-8c95-3a8c973dfafe" ;
```

and from that moment on:
```
SELECT current_user;
                         current_user                          
---------------------------------------------------------------
 development_cartodb_user_699ab2dc-dd77-4395-8c95-3a8c973dfafe
(1 row)

SELECT count(1) FROM amazon.cliwoc21 ;
 count  
--------
 282322
(1 row)
```