### PR TITLE
PG federated server setup

### DIFF
--- a/scripts-available/CDB_PG_Federated_Tables.sql
+++ b/scripts-available/CDB_PG_Federated_Tables.sql
@@ -4,7 +4,7 @@
 
 -- Take a config jsonb and transform it to an input suitable for
 -- _CDB_SetUp_User_PG_FDW_Server
-CREATE OR REPLACE FUNCTION @extschema@.__cdb_credentials_to_user_mapping(input_config jsonb)
+CREATE OR REPLACE FUNCTION @extschema@.__ft_credentials_to_user_mapping(input_config jsonb)
 RETURNS jsonb
 AS $$
 DECLARE
@@ -24,7 +24,7 @@ LANGUAGE PLPGSQL IMMUTABLE PARALLEL SAFE;
 
 -- Take a config jsonb as input and return it augmented with default
 -- options
-CREATE OR REPLACE FUNCTION @extschema@.__cdb_add_default_options(input_config jsonb)
+CREATE OR REPLACE FUNCTION @extschema@.__ft_add_default_options(input_config jsonb)
 RETURNS jsonb
 AS $$
 DECLARE
@@ -63,8 +63,8 @@ AS $$
 DECLARE
     final_config jsonb;
 BEGIN
-    final_config := @extschema@.__cdb_credentials_to_user_mapping(
-        @extschema@.__cdb_add_default_options(server_config)
+    final_config := @extschema@.__ft_credentials_to_user_mapping(
+        @extschema@.__ft_add_default_options(server_config)
     );
     PERFORM cartodb._CDB_SetUp_User_PG_FDW_Server(server_alias, final_config::json);
 END

--- a/scripts-available/CDB_PG_Federated_Tables.sql
+++ b/scripts-available/CDB_PG_Federated_Tables.sql
@@ -1,0 +1,27 @@
+----------------------------------------------------------------------
+-- Federated Tables management functions
+----------------------------------------------------------------------
+
+
+--
+-- Set up a federated server for later connection of tables/views
+-- E.g:
+-- SELECT cartodb.CDB_SetUp_PG_Federated_Server('amazon', '{
+--    "server": {
+--      "dbname": "testdb",
+--      "host": "myhostname.us-east-2.rds.amazonaws.com",
+--      "port": "5432"
+--    },
+--    "credentials": {
+--      "username": "read_only_user",
+--      "password": "secret"
+--    }
+-- }');
+CREATE OR REPLACE FUNCTION @extschema@.CDB_SetUp_PG_Federated_Server(server_alias text, config json)
+RETURNS void
+AS $$
+BEGIN
+    -- TODO
+END
+$$
+LANGUAGE PLPGSQL VOLATILE PARALLEL UNSAFE;

--- a/scripts-available/CDB_PG_Federated_Tables.sql
+++ b/scripts-available/CDB_PG_Federated_Tables.sql
@@ -17,11 +17,11 @@
 --      "password": "secret"
 --    }
 -- }');
-CREATE OR REPLACE FUNCTION @extschema@.CDB_SetUp_PG_Federated_Server(server_alias text, config json)
+CREATE OR REPLACE FUNCTION @extschema@.CDB_SetUp_PG_Federated_Server(server_alias text, server_config json)
 RETURNS void
 AS $$
 BEGIN
-    -- TODO
+    PERFORM cartodb._CDB_SetUp_User_PG_FDW_Server(server_alias, server_config);
 END
 $$
 LANGUAGE PLPGSQL VOLATILE PARALLEL UNSAFE;

--- a/scripts-available/CDB_PG_Federated_Tables.sql
+++ b/scripts-available/CDB_PG_Federated_Tables.sql
@@ -2,6 +2,25 @@
 -- Federated Tables management functions
 ----------------------------------------------------------------------
 
+-- Take a server_config jsonb and transform it to an input suitable
+-- for _CDB_SetUp_User_PG_FDW_Server
+CREATE OR REPLACE FUNCTION @extschema@.__cdb_credentials_to_user_mapping(input_config jsonb)
+RETURNS jsonb
+AS $$
+DECLARE
+    user_mapping jsonb;
+BEGIN
+    user_mapping := json_build_object('user_mapping',
+        jsonb_build_object(
+            'user', input_config->'credentials'->'username',
+            'password', input_config->'credentials'->'password'
+        )
+    );
+    RETURN (input_config - 'credentials')::jsonb || user_mapping;
+END
+$$
+LANGUAGE PLPGSQL IMMUTABLE PARALLEL SAFE;
+
 
 --
 -- Set up a federated server for later connection of tables/views
@@ -17,11 +36,14 @@
 --      "password": "secret"
 --    }
 -- }');
-CREATE OR REPLACE FUNCTION @extschema@.CDB_SetUp_PG_Federated_Server(server_alias text, server_config json)
+CREATE OR REPLACE FUNCTION @extschema@.CDB_SetUp_PG_Federated_Server(server_alias text, server_config jsonb)
 RETURNS void
 AS $$
+DECLARE
+    final_config jsonb;
 BEGIN
-    PERFORM cartodb._CDB_SetUp_User_PG_FDW_Server(server_alias, server_config);
+    final_config := @extschema@.__cdb_credentials_to_user_mapping(server_config);
+    PERFORM cartodb._CDB_SetUp_User_PG_FDW_Server(server_alias, final_config::json);
 END
 $$
 LANGUAGE PLPGSQL VOLATILE PARALLEL UNSAFE;

--- a/scripts-enabled/255-CDB_PG_Federated_Tables.sql
+++ b/scripts-enabled/255-CDB_PG_Federated_Tables.sql
@@ -1,0 +1,1 @@
+../scripts-available/CDB_PG_Federated_Tables.sql

--- a/test/extension/test.sh
+++ b/test/extension/test.sh
@@ -683,12 +683,17 @@ function test_federated_tables() {
      "host": "localhost",
      "port": ${PGPORT:-5432}
    },
-   "user_mapping": {
-     "user": "fdw_user",
+   "credentials": {
+     "username": "fdw_user",
      "password": "foobarino"
    }
 }
 EOF
+
+    # Unit-test this helper method
+    sql postgres "SELECT cartodb.__cdb_credentials_to_user_mapping('$federated_server_config')" \
+        should '{"server": {"host": "localhost", "port": 5432, "dbname": "fdw_target"}, "user_mapping": {"user": "fdw_user", "password": "foobarino"}}'
+
     # There must be a function with the expected interface
     sql postgres "SELECT cartodb.CDB_SetUp_PG_Federated_Server('my_server', '$federated_server_config');"
 
@@ -699,6 +704,7 @@ EOF
     sql cdb_testmember_1 'SELECT * from "cdb_fdw_my_server".foo;'
     sql cdb_testmember_1 'SELECT a from "cdb_fdw_my_server".foo LIMIT 1;' should 42
 
+    # Tear down
     sql postgres "SELECT cartodb._CDB_Drop_User_PG_FDW_Server('my_server', /* force = */ true)"
     tear_down_fdw_target
 }

--- a/test/extension/test.sh
+++ b/test/extension/test.sh
@@ -663,6 +663,9 @@ EOF
     DATABASE=fdw_target tear_down_database
 }
 
+function test_federated_tables() {
+}
+
 function test_cdb_catalog_basic_node() {
     DEF="'{\"type\":\"buffer\",\"source\":\"b2db66bc7ac02e135fd20bbfef0fdd81b2d15fad\",\"radio\":10000}'"
     sql postgres "INSERT INTO cartodb.cdb_analysis_catalog (node_id, analysis_def) VALUES ('1bbc4c41ea7c9d3a7dc1509727f698b7', ${DEF}::json)"

--- a/test/extension/test.sh
+++ b/test/extension/test.sh
@@ -503,8 +503,10 @@ function test_cdb_querytables_happy_cases() {
 }
 
 function setup_fdw_target() {
-    DATABASE=fdw_target setup_database
-    DATABASE=fdw_target sql postgres "DO
+    local DATABASE=fdw_target
+
+    setup_database
+    sql postgres "DO
 \$\$
 BEGIN
    IF NOT EXISTS (
@@ -517,34 +519,35 @@ BEGIN
 END
 \$\$;"
 
-    DATABASE=fdw_target sql postgres 'CREATE SCHEMA test_fdw;'
-    DATABASE=fdw_target sql postgres 'CREATE TABLE test_fdw.foo (a int);'
-    DATABASE=fdw_target sql postgres 'INSERT INTO test_fdw.foo (a) values (42);'
-    DATABASE=fdw_target sql postgres 'CREATE TABLE test_fdw.foo2 (a int);'
-    DATABASE=fdw_target sql postgres 'INSERT INTO test_fdw.foo2 (a) values (42);'
-    DATABASE=fdw_target sql postgres "CREATE USER fdw_user WITH PASSWORD 'foobarino';"
-    DATABASE=fdw_target sql postgres 'GRANT USAGE ON SCHEMA test_fdw TO fdw_user;'
-    DATABASE=fdw_target sql postgres 'GRANT SELECT ON TABLE test_fdw.foo TO fdw_user;'
-    DATABASE=fdw_target sql postgres 'GRANT SELECT ON TABLE test_fdw.foo2 TO fdw_user;'
-    DATABASE=fdw_target sql postgres 'GRANT SELECT ON cdb_tablemetadata_text TO fdw_user;'
+    sql postgres 'CREATE SCHEMA test_fdw;'
+    sql postgres 'CREATE TABLE test_fdw.foo (a int);'
+    sql postgres 'INSERT INTO test_fdw.foo (a) values (42);'
+    sql postgres 'CREATE TABLE test_fdw.foo2 (a int);'
+    sql postgres 'INSERT INTO test_fdw.foo2 (a) values (42);'
+    sql postgres "CREATE USER fdw_user WITH PASSWORD 'foobarino';"
+    sql postgres 'GRANT USAGE ON SCHEMA test_fdw TO fdw_user;'
+    sql postgres 'GRANT SELECT ON TABLE test_fdw.foo TO fdw_user;'
+    sql postgres 'GRANT SELECT ON TABLE test_fdw.foo2 TO fdw_user;'
+    sql postgres 'GRANT SELECT ON cdb_tablemetadata_text TO fdw_user;'
 
-    DATABASE=fdw_target sql postgres "SELECT cdb_tablemetadatatouch('test_fdw.foo'::regclass);"
-    DATABASE=fdw_target sql postgres "SELECT cdb_tablemetadatatouch('test_fdw.foo2'::regclass);"
+    sql postgres "SELECT cdb_tablemetadatatouch('test_fdw.foo'::regclass);"
+    sql postgres "SELECT cdb_tablemetadatatouch('test_fdw.foo2'::regclass);"
 }
 
 function tear_down_fdw_target() {
-    DATABASE=fdw_target sql postgres 'REVOKE USAGE ON SCHEMA test_fdw FROM fdw_user;'
-    DATABASE=fdw_target sql postgres 'REVOKE SELECT ON test_fdw.foo FROM fdw_user;'
-    DATABASE=fdw_target sql postgres 'REVOKE SELECT ON test_fdw.foo2 FROM fdw_user;'
-    DATABASE=fdw_target sql postgres 'REVOKE SELECT ON cdb_tablemetadata_text FROM fdw_user;'
-    DATABASE=fdw_target sql postgres 'DROP ROLE fdw_user;'
+    local DATABASE=fdw_target
 
-    sql postgres "select pg_terminate_backend(pid) from pg_stat_activity where datname='fdw_target';"
+    sql postgres 'REVOKE USAGE ON SCHEMA test_fdw FROM fdw_user;'
+    sql postgres 'REVOKE SELECT ON test_fdw.foo FROM fdw_user;'
+    sql postgres 'REVOKE SELECT ON test_fdw.foo2 FROM fdw_user;'
+    sql postgres 'REVOKE SELECT ON cdb_tablemetadata_text FROM fdw_user;'
+    sql postgres 'DROP ROLE fdw_user;'
+
+    DATABASE=test_extension sql postgres "select pg_terminate_backend(pid) from pg_stat_activity where datname='fdw_target';"
     DATABASE=fdw_target tear_down_database
 }
 
 function test_foreign_tables() {
-
     setup_fdw_target
 
     # Add PGPORT to conf if it is set

--- a/test/extension/test.sh
+++ b/test/extension/test.sh
@@ -690,7 +690,7 @@ function test_federated_tables() {
 }
 EOF
 
-    # Unit-test __cdb_credentials_to_user_mapping
+    # Unit-test __ft_credentials_to_user_mapping
     read -d '' expected_user_mapping <<- EOF
 {
     "server": {
@@ -704,10 +704,10 @@ EOF
     }
 }
 EOF
-    sql postgres "SELECT cartodb.__cdb_credentials_to_user_mapping('$federated_server_config') = '$expected_user_mapping'" \
+    sql postgres "SELECT cartodb.__ft_credentials_to_user_mapping('$federated_server_config') = '$expected_user_mapping'" \
         should 't'
 
-    # Unit-test __cdb_add_default_options
+    # Unit-test __ft_add_default_options
     read -d '' expected_default_options <<- EOF
 {
     "server": {
@@ -725,7 +725,7 @@ EOF
     }
 }
 EOF
-    sql postgres "SELECT cartodb.__cdb_add_default_options('$federated_server_config') = '$expected_default_options'" \
+    sql postgres "SELECT cartodb.__ft_add_default_options('$federated_server_config') = '$expected_default_options'" \
         should 't'
 
     # There must be a function with the expected interface


### PR DESCRIPTION
This branch adds a new function `CDB_SetUp_PG_Federated_Server` that can be used like this:
```sql
SELECT cartodb.CDB_SetUp_PG_Federated_Server('amazon', '{
   "server": {
     "dbname": "testdb",
     "host": "myhostname.us-east-2.rds.amazonaws.com",
     "port": "5432"
   },
   "credentials": {
     "username": "read_only_user",
     "password": "secret"
   }
}');
```

As a bonus it has a small refactor of tests, extracting some common setup and teardown from FDW tests.
