### PR TITLE
PG Federated Tables

### DIFF
--- a/scripts-available/CDB_PG_Federated_Tables.sql
+++ b/scripts-available/CDB_PG_Federated_Tables.sql
@@ -114,7 +114,7 @@ $$ LANGUAGE SQL;
 --    }
 -- }');
 --
-CREATE OR REPLACE FUNCTION @extschema@.CDB_SetUp_PG_Federated_Server(server_alias text, server_config jsonb)
+CREATE OR REPLACE FUNCTION @extschema@.CDB_SetUp_PG_Federated_Server(server_alias name, server_config jsonb)
 RETURNS void
 AS $$
 DECLARE
@@ -149,7 +149,7 @@ LANGUAGE PLPGSQL VOLATILE PARALLEL UNSAFE;
 -- );
 --
 CREATE OR REPLACE FUNCTION @extschema@.CDB_SetUp_PG_Federated_Table(
-    server_alias text,
+    server_alias name,
     schema_name name,
     table_name name,
     id_column name,
@@ -229,7 +229,7 @@ LANGUAGE PLPGSQL VOLATILE PARALLEL UNSAFE;
 
 
 CREATE OR REPLACE FUNCTION @extschema@.CDB_SetUp_PG_Federated_Table(
-    server_alias text,
+    server_alias name,
     schema_name name,
     table_name name,
     id_column name,
@@ -250,7 +250,7 @@ LANGUAGE SQL VOLATILE PARALLEL UNSAFE;
 
 
 CREATE OR REPLACE FUNCTION @extschema@.CDB_SetUp_PG_Federated_Table(
-    server_alias text,
+    server_alias name,
     schema_name name,
     table_name name,
     id_column name

--- a/scripts-available/CDB_PG_Federated_Tables.sql
+++ b/scripts-available/CDB_PG_Federated_Tables.sql
@@ -123,7 +123,7 @@ BEGIN
     final_config := @extschema@.__ft_credentials_to_user_mapping(
         @extschema@.__ft_add_default_readonly_options(server_config)
     );
-    PERFORM cartodb._CDB_SetUp_User_PG_FDW_Server(server_alias, final_config::json);
+    PERFORM @extschema@._CDB_SetUp_User_PG_FDW_Server(server_alias, final_config::json);
 END
 $$
 LANGUAGE PLPGSQL VOLATILE PARALLEL UNSAFE;
@@ -166,7 +166,7 @@ DECLARE
     webmercator_expression TEXT;
 BEGIN
     -- Import the foreign table
-    PERFORM CDB_SetUp_User_PG_FDW_Table(server_alias, schema_name, table_name);
+    PERFORM @extschema@.CDB_SetUp_User_PG_FDW_Table(server_alias, schema_name, table_name);
     src_table := format('%s.%s', fdw_objects_name, table_name);
 
     -- Check id_column is numeric
@@ -193,7 +193,7 @@ BEGIN
     THEN
         geom_expression := format('t.%I AS the_geom', geom_column);
     ELSE
-        geom_expression := format('ST_Transform(t.%I, 4326) AS the_geom', geom_column);
+        geom_expression := format('@postgisschema@.ST_Transform(t.%I, 4326) AS the_geom', geom_column);
     END IF;
 
     -- Figure out whether a ST_Transform to 3857 is needed or not
@@ -201,7 +201,7 @@ BEGIN
     THEN
         webmercator_expression := format('t.%I AS the_geom_webmercator', webmercator_column);
     ELSE
-        webmercator_expression := format('ST_Transform(t.%I, 3857) AS the_geom_webmercator', webmercator_column);
+        webmercator_expression := format('@postgisschema@.ST_Transform(t.%I, 3857) AS the_geom_webmercator', webmercator_column);
     END IF;
 
     -- Create a view with homogeneous CDB fields
@@ -263,7 +263,7 @@ DECLARE
     rest_of_cols TEXT[];
 BEGIN
     -- Import the foreign table
-    PERFORM CDB_SetUp_User_PG_FDW_Table(server_alias, schema_name, table_name);
+    PERFORM @extschema@.CDB_SetUp_User_PG_FDW_Table(server_alias, schema_name, table_name);
     src_table := format('%s.%s', fdw_objects_name, table_name);
 
     -- Check id_column is numeric

--- a/scripts-available/CDB_PG_Federated_Tables.sql
+++ b/scripts-available/CDB_PG_Federated_Tables.sql
@@ -4,7 +4,7 @@
 
 -- Take a config jsonb and transform it to an input suitable for
 -- _CDB_SetUp_User_PG_FDW_Server
-CREATE OR REPLACE FUNCTION @extschema@.__cdb_credentials_to_user_mapping(input_config jsonb)
+CREATE OR REPLACE FUNCTION @extschema@.__ft_credentials_to_user_mapping(input_config jsonb)
 RETURNS jsonb
 AS $$
 DECLARE
@@ -24,7 +24,7 @@ LANGUAGE PLPGSQL IMMUTABLE PARALLEL SAFE;
 
 -- Take a config jsonb as input and return it augmented with default
 -- options
-CREATE OR REPLACE FUNCTION @extschema@.__cdb_add_default_options(input_config jsonb)
+CREATE OR REPLACE FUNCTION @extschema@.__ft_add_default_options(input_config jsonb)
 RETURNS jsonb
 AS $$
 DECLARE
@@ -63,8 +63,8 @@ AS $$
 DECLARE
     final_config jsonb;
 BEGIN
-    final_config := @extschema@.__cdb_credentials_to_user_mapping(
-        @extschema@.__cdb_add_default_options(server_config)
+    final_config := @extschema@.__ft_credentials_to_user_mapping(
+        @extschema@.__ft_add_default_options(server_config)
     );
     PERFORM cartodb._CDB_SetUp_User_PG_FDW_Server(server_alias, final_config::json);
 END

--- a/scripts-available/CDB_PG_Federated_Tables.sql
+++ b/scripts-available/CDB_PG_Federated_Tables.sql
@@ -189,7 +189,7 @@ BEGIN
     ) INTO rest_of_cols;
 
     -- Figure out whether a ST_Transform to 4326 is needed or not
-    IF Find_SRID(fdw_objects_name::varchar, table_name::varchar, geom_column::varchar) = 4326
+    IF @postgisschema@.Find_SRID(fdw_objects_name::varchar, table_name::varchar, geom_column::varchar) = 4326
     THEN
         geom_expression := format('t.%I AS the_geom', geom_column);
     ELSE

--- a/scripts-available/CDB_PG_Federated_Tables.sql
+++ b/scripts-available/CDB_PG_Federated_Tables.sql
@@ -24,7 +24,7 @@ LANGUAGE PLPGSQL IMMUTABLE PARALLEL SAFE;
 
 -- Take a config jsonb as input and return it augmented with default
 -- options
-CREATE OR REPLACE FUNCTION @extschema@.__ft_add_default_options(input_config jsonb)
+CREATE OR REPLACE FUNCTION @extschema@.__ft_add_default_readonly_options(input_config jsonb)
 RETURNS jsonb
 AS $$
 DECLARE
@@ -125,7 +125,7 @@ DECLARE
     final_config jsonb;
 BEGIN
     final_config := @extschema@.__ft_credentials_to_user_mapping(
-        @extschema@.__ft_add_default_options(server_config)
+        @extschema@.__ft_add_default_readonly_options(server_config)
     );
     PERFORM cartodb._CDB_SetUp_User_PG_FDW_Server(server_alias, final_config::json);
 END

--- a/scripts-available/CDB_PG_Federated_Tables.sql
+++ b/scripts-available/CDB_PG_Federated_Tables.sql
@@ -171,7 +171,7 @@ BEGIN
 
     -- Check id_column is numeric
     IF NOT @extschema@.__ft_is_numeric(src_table, id_column) THEN
-        RAISE EXCEPTION 'non integer id_column "%"', id_colun;
+        RAISE EXCEPTION 'non integer id_column "%"', id_column;
     END IF;
 
     -- Check if the geom and mercator columns have a geometry type
@@ -268,7 +268,7 @@ BEGIN
 
     -- Check id_column is numeric
     IF NOT @extschema@.__ft_is_numeric(src_table, id_column) THEN
-        RAISE EXCEPTION 'non integer id_column "%"', id_colun;
+        RAISE EXCEPTION 'non integer id_column "%"', id_column;
     END IF;
 
     -- Get a list of columns excluding the id

--- a/scripts-available/CDB_PG_Federated_Tables.sql
+++ b/scripts-available/CDB_PG_Federated_Tables.sql
@@ -54,7 +54,7 @@ BEGIN
            WHERE typname IN
              ('smallint', 'integer', 'bigint', 'int2', 'int4', 'int8'));
     IF NOT FOUND THEN
-      RAISE EXCEPTION 'non integer id_column "%"', id_column;
+      RAISE EXCEPTION 'non integer id_column "%"', colname;
     END IF;
 END
 $$
@@ -70,7 +70,7 @@ BEGIN
            AND attname = colname
            AND atttypid = 'geometry'::regtype;
     IF NOT FOUND THEN
-        RAISE EXCEPTION 'non geometry column "%"', geom_colum;
+        RAISE EXCEPTION 'non geometry column "%"', colname;
     END IF;
 END
 $$

--- a/scripts-available/CDB_PG_Federated_Tables.sql
+++ b/scripts-available/CDB_PG_Federated_Tables.sql
@@ -1,0 +1,27 @@
+----------------------------------------------------------------------
+-- Federated Tables management functions
+----------------------------------------------------------------------
+
+
+--
+-- Set up a federated server for later connection of tables/views
+-- E.g:
+-- SELECT cartodb.CDB_SetUp_PG_Federated_Server('amazon', '{
+--    "server": {
+--      "dbname": "testdb",
+--      "host": "myhostname.us-east-2.rds.amazonaws.com",
+--      "port": "5432"
+--    },
+--    "credentials": {
+--      "username": "read_only_user",
+--      "password": "secret"
+--    }
+-- }');
+CREATE OR REPLACE FUNCTION @extschema@.CDB_SetUp_PG_Federated_Server(server_alias text, config json)
+RETURNS void
+AS $$
+BEGIN
+    -- TODO
+END
+$$
+LANGUAGE PLPGSQL VOLATILE PARALLEL UNSAFE;

--- a/scripts-available/CDB_PG_Federated_Tables.sql
+++ b/scripts-available/CDB_PG_Federated_Tables.sql
@@ -17,11 +17,11 @@
 --      "password": "secret"
 --    }
 -- }');
-CREATE OR REPLACE FUNCTION @extschema@.CDB_SetUp_PG_Federated_Server(server_alias text, config json)
+CREATE OR REPLACE FUNCTION @extschema@.CDB_SetUp_PG_Federated_Server(server_alias text, server_config json)
 RETURNS void
 AS $$
 BEGIN
-    -- TODO
+    PERFORM cartodb._CDB_SetUp_User_PG_FDW_Server(server_alias, server_config);
 END
 $$
 LANGUAGE PLPGSQL VOLATILE PARALLEL UNSAFE;

--- a/scripts-available/CDB_PG_Federated_Tables.sql
+++ b/scripts-available/CDB_PG_Federated_Tables.sql
@@ -267,7 +267,9 @@ BEGIN
     src_table := format('%s.%s', fdw_objects_name, table_name);
 
     -- Check id_column is numeric
-    PERFORM @extschema@.__ft_assert_numeric(src_table, id_column);
+    IF NOT @extschema@.__ft_is_numeric(src_table, id_column) THEN
+        RAISE EXCEPTION 'non integer id_column "%"', id_colun;
+    END IF;
 
     -- Get a list of columns excluding the id
     SELECT ARRAY(

--- a/scripts-available/CDB_PG_Federated_Tables.sql
+++ b/scripts-available/CDB_PG_Federated_Tables.sql
@@ -2,6 +2,25 @@
 -- Federated Tables management functions
 ----------------------------------------------------------------------
 
+-- Take a server_config jsonb and transform it to an input suitable
+-- for _CDB_SetUp_User_PG_FDW_Server
+CREATE OR REPLACE FUNCTION @extschema@.__cdb_credentials_to_user_mapping(input_config jsonb)
+RETURNS jsonb
+AS $$
+DECLARE
+    user_mapping jsonb;
+BEGIN
+    user_mapping := json_build_object('user_mapping',
+        jsonb_build_object(
+            'user', input_config->'credentials'->'username',
+            'password', input_config->'credentials'->'password'
+        )
+    );
+    RETURN (input_config - 'credentials')::jsonb || user_mapping;
+END
+$$
+LANGUAGE PLPGSQL IMMUTABLE PARALLEL SAFE;
+
 
 --
 -- Set up a federated server for later connection of tables/views
@@ -17,11 +36,14 @@
 --      "password": "secret"
 --    }
 -- }');
-CREATE OR REPLACE FUNCTION @extschema@.CDB_SetUp_PG_Federated_Server(server_alias text, server_config json)
+CREATE OR REPLACE FUNCTION @extschema@.CDB_SetUp_PG_Federated_Server(server_alias text, server_config jsonb)
 RETURNS void
 AS $$
+DECLARE
+    final_config jsonb;
 BEGIN
-    PERFORM cartodb._CDB_SetUp_User_PG_FDW_Server(server_alias, server_config);
+    final_config := @extschema@.__cdb_credentials_to_user_mapping(server_config);
+    PERFORM cartodb._CDB_SetUp_User_PG_FDW_Server(server_alias, final_config::json);
 END
 $$
 LANGUAGE PLPGSQL VOLATILE PARALLEL UNSAFE;

--- a/scripts-available/CDB_PG_Federated_Tables.sql
+++ b/scripts-available/CDB_PG_Federated_Tables.sql
@@ -117,6 +117,7 @@ $$ LANGUAGE SQL;
 --      "password": "secret"
 --    }
 -- }');
+--
 CREATE OR REPLACE FUNCTION @extschema@.CDB_SetUp_PG_Federated_Server(server_alias text, server_config jsonb)
 RETURNS void
 AS $$
@@ -133,7 +134,13 @@ LANGUAGE PLPGSQL VOLATILE PARALLEL UNSAFE;
 
 
 --
--- Set up a federated table
+-- Set up a Federated Table
+--
+-- Precondition: the federated server has to be set up via
+-- CDB_SetUp_PG_Federated_Server
+--
+-- Postcondition: it generates a view in the schema of the user that
+-- can be used through SQL and Maps API's.
 --
 -- E.g:
 -- SELECT cartodb.CDB_SetUp_PG_Federated_Table(
@@ -144,6 +151,7 @@ LANGUAGE PLPGSQL VOLATILE PARALLEL UNSAFE;
 --   'geom',                    -- optional, name of the geom column, preferably in 4326
 --   'webmercator',             -- optional, must be in 3857 if present
 -- );
+--
 CREATE OR REPLACE FUNCTION @extschema@.CDB_SetUp_PG_Federated_Table(
     server_alias text,
     schema_name name,

--- a/scripts-enabled/255-CDB_PG_Federated_Tables.sql
+++ b/scripts-enabled/255-CDB_PG_Federated_Tables.sql
@@ -1,0 +1,1 @@
+../scripts-available/CDB_PG_Federated_Tables.sql

--- a/test/extension/test.sh
+++ b/test/extension/test.sh
@@ -745,35 +745,35 @@ EOF
 
 
     # It shall be able to register a fully cartodbfied table
-    DATABASE=fdw_target sql postgres 'CREATE TABLE test_fdw.carto_remote_table (cartodb_id int,  another_field text, geom geometry(Geometry,4326));'
-    DATABASE=fdw_target sql postgres "INSERT INTO test_fdw.carto_remote_table VALUES (1, 'patata', cartodb.CDB_LatLng(0, 0));"
-    DATABASE=fdw_target sql postgres "SELECT cartodb.CDB_CartodbfyTable('test_fdw', 'test_fdw.carto_remote_table');"
-    DATABASE=fdw_target sql postgres 'GRANT SELECT ON TABLE test_fdw.carto_remote_table TO fdw_user;'
+    DATABASE=fdw_target sql postgres 'CREATE TABLE test_fdw.remote_table (cartodb_id int,  another_field text, geom geometry(Geometry,4326));'
+    DATABASE=fdw_target sql postgres "INSERT INTO test_fdw.remote_table VALUES (1, 'patata', cartodb.CDB_LatLng(0, 0));"
+    DATABASE=fdw_target sql postgres "SELECT cartodb.CDB_CartodbfyTable('test_fdw', 'test_fdw.remote_table');"
+    DATABASE=fdw_target sql postgres 'GRANT SELECT ON TABLE test_fdw.remote_table TO fdw_user;'
 
     sql cdb_testmember_1 "SELECT cartodb.CDB_SetUp_PG_Federated_Table(
-                              'my_server', -- server alias
-                              'test_fdw', -- schema
-                              'carto_remote_table', -- table
-                              'cartodb_id', -- id column
-                              'the_geom', -- geom column
-                              'the_geom_webmercator' -- mercator column
+                              'my_server',
+                              'test_fdw',
+                              'remote_table',
+                              'cartodb_id',
+                              'the_geom',
+                              'the_geom_webmercator'
                           )"
 
      # Now it shall be able to access the table/view from its schema
-    sql cdb_testmember_1 "SELECT * FROM carto_remote_table;"
+    sql cdb_testmember_1 "SELECT * FROM remote_table;"
 
 
     # It checks that the id column is numeric
-    DATABASE=fdw_target sql postgres 'CREATE TABLE test_fdw.carto_remote_table2 (cartodb_id text,  another_field text, geom geometry(Geometry,4326));'
-    DATABASE=fdw_target sql postgres 'GRANT SELECT ON TABLE test_fdw.carto_remote_table2 TO fdw_user;'
+    DATABASE=fdw_target sql postgres 'CREATE TABLE test_fdw.remote_table2 (cartodb_id text,  another_field text, geom geometry(Geometry,4326));'
+    DATABASE=fdw_target sql postgres 'GRANT SELECT ON TABLE test_fdw.remote_table2 TO fdw_user;'
 
     sql cdb_testmember_1 "SELECT cartodb.CDB_SetUp_PG_Federated_Table(
-                              'my_server', -- server alias
-                              'test_fdw', -- schema
-                              'carto_remote_table2', -- table
-                              'another_field', -- id column
-                              'the_geom', -- geom column
-                              'the_geom_webmercator' -- mercator column
+                              'my_server',
+                              'test_fdw',
+                              'remote_table2',
+                              'another_field',
+                              'the_geom',
+                              'the_geom_webmercator'
                           )" fails
 
 

--- a/test/extension/test.sh
+++ b/test/extension/test.sh
@@ -683,12 +683,17 @@ function test_federated_tables() {
      "host": "localhost",
      "port": ${PGPORT:-5432}
    },
-   "user_mapping": {
-     "user": "fdw_user",
+   "credentials": {
+     "username": "fdw_user",
      "password": "foobarino"
    }
 }
 EOF
+
+    # Unit-test this helper method
+    sql postgres "SELECT cartodb.__cdb_credentials_to_user_mapping('$federated_server_config')" \
+        should '{"server": {"host": "localhost", "port": 5432, "dbname": "fdw_target"}, "user_mapping": {"user": "fdw_user", "password": "foobarino"}}'
+
     # There must be a function with the expected interface
     sql postgres "SELECT cartodb.CDB_SetUp_PG_Federated_Server('my_server', '$federated_server_config');"
 
@@ -699,6 +704,7 @@ EOF
     sql cdb_testmember_1 'SELECT * from "cdb_fdw_my_server".foo;'
     sql cdb_testmember_1 'SELECT a from "cdb_fdw_my_server".foo LIMIT 1;' should 42
 
+    # Tear down
     sql postgres "SELECT cartodb._CDB_Drop_User_PG_FDW_Server('my_server', /* force = */ true)"
     tear_down_fdw_target
 }

--- a/test/extension/test.sh
+++ b/test/extension/test.sh
@@ -709,7 +709,7 @@ EOF
     sql postgres "SELECT cartodb.__ft_credentials_to_user_mapping('$federated_server_config') = '$expected_user_mapping'" \
         should 't'
 
-    # Unit-test __ft_add_default_options
+    # Unit-test __ft_add_default_readonly_options
     read -d '' expected_default_options <<- EOF
 {
     "server": {
@@ -727,7 +727,7 @@ EOF
     }
 }
 EOF
-    sql postgres "SELECT cartodb.__ft_add_default_options('$federated_server_config') = '$expected_default_options'" \
+    sql postgres "SELECT cartodb.__ft_add_default_readonly_options('$federated_server_config') = '$expected_default_options'" \
         should 't'
 
     # There must be a function with the expected interface

--- a/test/extension/test.sh
+++ b/test/extension/test.sh
@@ -821,6 +821,19 @@ EOF
    FROM cdb_fdw_my_server.remote_table4 t;'
 
 
+    # It shall work without any geometries
+    DATABASE=fdw_target sql postgres 'CREATE TABLE test_fdw.remote_table5 (id int,  another_field text);'
+    DATABASE=fdw_target sql postgres 'GRANT SELECT ON TABLE test_fdw.remote_table5 TO fdw_user;'
+    DATABASE=fdw_target sql postgres "INSERT INTO test_fdw.remote_table5 VALUES (1, 'patata');"
+    sql cdb_testmember_1 "SELECT cartodb.CDB_SetUp_PG_Federated_Table(
+                              'my_server',
+                              'test_fdw',
+                              'remote_table5',
+                              'id'
+                          )"
+    sql cdb_testmember_1 "SELECT cartodb_id, another_field, the_geom, the_geom_webmercator FROM remote_table5;" should '1|patata||'
+
+
     # Tear down
     DATABASE=fdw_target sql postgres 'REVOKE ALL ON ALL TABLES IN SCHEMA test_fdw FROM fdw_user;'
     sql postgres "SELECT cartodb._CDB_Drop_User_PG_FDW_Server('my_server', /* force = */ true)"

--- a/test/extension/test.sh
+++ b/test/extension/test.sh
@@ -663,6 +663,9 @@ EOF
     DATABASE=fdw_target tear_down_database
 }
 
+function test_federated_tables() {
+}
+
 function test_cdb_catalog_basic_node() {
     DEF="'{\"type\":\"buffer\",\"source\":\"b2db66bc7ac02e135fd20bbfef0fdd81b2d15fad\",\"radio\":10000}'"
     sql postgres "INSERT INTO cartodb.cdb_analysis_catalog (node_id, analysis_def) VALUES ('1bbc4c41ea7c9d3a7dc1509727f698b7', ${DEF}::json)"

--- a/test/extension/test.sh
+++ b/test/extension/test.sh
@@ -763,6 +763,20 @@ EOF
     sql cdb_testmember_1 "SELECT * FROM carto_remote_table;"
 
 
+    # It checks that the id column is numeric
+    DATABASE=fdw_target sql postgres 'CREATE TABLE test_fdw.carto_remote_table2 (cartodb_id text,  another_field text, geom geometry(Geometry,4326));'
+    DATABASE=fdw_target sql postgres 'GRANT SELECT ON TABLE test_fdw.carto_remote_table2 TO fdw_user;'
+
+    sql cdb_testmember_1 "SELECT cartodb.CDB_SetUp_PG_Federated_Table(
+                              'my_server', -- server alias
+                              'test_fdw', -- schema
+                              'carto_remote_table2', -- table
+                              'another_field', -- id column
+                              'the_geom', -- geom column
+                              'the_geom_webmercator' -- mercator column
+                          )" fails
+
+
     # Tear down
     DATABASE=fdw_target sql postgres 'REVOKE ALL ON ALL TABLES IN SCHEMA test_fdw FROM fdw_user;'
     sql postgres "SELECT cartodb._CDB_Drop_User_PG_FDW_Server('my_server', /* force = */ true)"

--- a/test/extension/test.sh
+++ b/test/extension/test.sh
@@ -503,8 +503,10 @@ function test_cdb_querytables_happy_cases() {
 }
 
 function setup_fdw_target() {
-    DATABASE=fdw_target setup_database
-    DATABASE=fdw_target sql postgres "DO
+    local DATABASE=fdw_target
+
+    setup_database
+    sql postgres "DO
 \$\$
 BEGIN
    IF NOT EXISTS (
@@ -517,34 +519,35 @@ BEGIN
 END
 \$\$;"
 
-    DATABASE=fdw_target sql postgres 'CREATE SCHEMA test_fdw;'
-    DATABASE=fdw_target sql postgres 'CREATE TABLE test_fdw.foo (a int);'
-    DATABASE=fdw_target sql postgres 'INSERT INTO test_fdw.foo (a) values (42);'
-    DATABASE=fdw_target sql postgres 'CREATE TABLE test_fdw.foo2 (a int);'
-    DATABASE=fdw_target sql postgres 'INSERT INTO test_fdw.foo2 (a) values (42);'
-    DATABASE=fdw_target sql postgres "CREATE USER fdw_user WITH PASSWORD 'foobarino';"
-    DATABASE=fdw_target sql postgres 'GRANT USAGE ON SCHEMA test_fdw TO fdw_user;'
-    DATABASE=fdw_target sql postgres 'GRANT SELECT ON TABLE test_fdw.foo TO fdw_user;'
-    DATABASE=fdw_target sql postgres 'GRANT SELECT ON TABLE test_fdw.foo2 TO fdw_user;'
-    DATABASE=fdw_target sql postgres 'GRANT SELECT ON cdb_tablemetadata_text TO fdw_user;'
+    sql postgres 'CREATE SCHEMA test_fdw;'
+    sql postgres 'CREATE TABLE test_fdw.foo (a int);'
+    sql postgres 'INSERT INTO test_fdw.foo (a) values (42);'
+    sql postgres 'CREATE TABLE test_fdw.foo2 (a int);'
+    sql postgres 'INSERT INTO test_fdw.foo2 (a) values (42);'
+    sql postgres "CREATE USER fdw_user WITH PASSWORD 'foobarino';"
+    sql postgres 'GRANT USAGE ON SCHEMA test_fdw TO fdw_user;'
+    sql postgres 'GRANT SELECT ON TABLE test_fdw.foo TO fdw_user;'
+    sql postgres 'GRANT SELECT ON TABLE test_fdw.foo2 TO fdw_user;'
+    sql postgres 'GRANT SELECT ON cdb_tablemetadata_text TO fdw_user;'
 
-    DATABASE=fdw_target sql postgres "SELECT cdb_tablemetadatatouch('test_fdw.foo'::regclass);"
-    DATABASE=fdw_target sql postgres "SELECT cdb_tablemetadatatouch('test_fdw.foo2'::regclass);"
+    sql postgres "SELECT cdb_tablemetadatatouch('test_fdw.foo'::regclass);"
+    sql postgres "SELECT cdb_tablemetadatatouch('test_fdw.foo2'::regclass);"
 }
 
 function tear_down_fdw_target() {
-    DATABASE=fdw_target sql postgres 'REVOKE USAGE ON SCHEMA test_fdw FROM fdw_user;'
-    DATABASE=fdw_target sql postgres 'REVOKE SELECT ON test_fdw.foo FROM fdw_user;'
-    DATABASE=fdw_target sql postgres 'REVOKE SELECT ON test_fdw.foo2 FROM fdw_user;'
-    DATABASE=fdw_target sql postgres 'REVOKE SELECT ON cdb_tablemetadata_text FROM fdw_user;'
-    DATABASE=fdw_target sql postgres 'DROP ROLE fdw_user;'
+    local DATABASE=fdw_target
 
-    sql postgres "select pg_terminate_backend(pid) from pg_stat_activity where datname='fdw_target';"
+    sql postgres 'REVOKE USAGE ON SCHEMA test_fdw FROM fdw_user;'
+    sql postgres 'REVOKE SELECT ON test_fdw.foo FROM fdw_user;'
+    sql postgres 'REVOKE SELECT ON test_fdw.foo2 FROM fdw_user;'
+    sql postgres 'REVOKE SELECT ON cdb_tablemetadata_text FROM fdw_user;'
+    sql postgres 'DROP ROLE fdw_user;'
+
+    DATABASE=test_extension sql postgres "select pg_terminate_backend(pid) from pg_stat_activity where datname='fdw_target';"
     DATABASE=fdw_target tear_down_database
 }
 
 function test_foreign_tables() {
-
     setup_fdw_target
 
     # Add PGPORT to conf if it is set

--- a/test/extension/test.sh
+++ b/test/extension/test.sh
@@ -690,7 +690,7 @@ function test_federated_tables() {
 }
 EOF
 
-    # Unit-test __cdb_credentials_to_user_mapping
+    # Unit-test __ft_credentials_to_user_mapping
     read -d '' expected_user_mapping <<- EOF
 {
     "server": {
@@ -704,10 +704,10 @@ EOF
     }
 }
 EOF
-    sql postgres "SELECT cartodb.__cdb_credentials_to_user_mapping('$federated_server_config') = '$expected_user_mapping'" \
+    sql postgres "SELECT cartodb.__ft_credentials_to_user_mapping('$federated_server_config') = '$expected_user_mapping'" \
         should 't'
 
-    # Unit-test __cdb_add_default_options
+    # Unit-test __ft_add_default_options
     read -d '' expected_default_options <<- EOF
 {
     "server": {
@@ -725,7 +725,7 @@ EOF
     }
 }
 EOF
-    sql postgres "SELECT cartodb.__cdb_add_default_options('$federated_server_config') = '$expected_default_options'" \
+    sql postgres "SELECT cartodb.__ft_add_default_options('$federated_server_config') = '$expected_default_options'" \
         should 't'
 
     # There must be a function with the expected interface

--- a/test/extension/test.sh
+++ b/test/extension/test.sh
@@ -745,8 +745,8 @@ EOF
 
 
     # It shall be able to register a fully cartodbfied table
-    DATABASE=fdw_target sql postgres 'CREATE TABLE test_fdw.carto_remote_table (id int, geom geometry(Geometry,4326));'
-    DATABASE=fdw_target sql postgres 'INSERT INTO test_fdw.carto_remote_table VALUES (1, cartodb.CDB_LatLng(0, 0));'
+    DATABASE=fdw_target sql postgres 'CREATE TABLE test_fdw.carto_remote_table (cartodb_id int,  another_field text, geom geometry(Geometry,4326));'
+    DATABASE=fdw_target sql postgres "INSERT INTO test_fdw.carto_remote_table VALUES (1, 'patata', cartodb.CDB_LatLng(0, 0));"
     DATABASE=fdw_target sql postgres "SELECT cartodb.CDB_CartodbfyTable('test_fdw', 'test_fdw.carto_remote_table');"
     DATABASE=fdw_target sql postgres 'GRANT SELECT ON TABLE test_fdw.carto_remote_table TO fdw_user;'
 


### PR DESCRIPTION
Built on top of https://github.com/CartoDB/cartodb-postgresql/pull/372

This adds a function `CDB_SetUp_PG_Federated_Table` with the following form:

```sql
SELECT cartodb.CDB_SetUp_PG_Federated_Table(
  'amazon', -- mandatory, name of the federated server
  'schema_name', -- mandatory
  'table_name', -- mandatory
  'id_column_name', -- mandatory
  'geom_column_name', -- optional, preferably in 4326
  'webmercator_column_name', -- optional, must be in 3857 if present
);
```