### PR TITLE
Avoid name clashing no geom columns provided but existing the_geom

### DIFF
--- a/scripts-available/CDB_PG_Federated_Tables.sql
+++ b/scripts-available/CDB_PG_Federated_Tables.sql
@@ -274,7 +274,7 @@ BEGIN
     -- Get a list of columns excluding the id
     SELECT ARRAY(
         SELECT quote_ident(c) FROM @extschema@.__ft_getcolumns(src_table) AS c
-        WHERE c <> id_column
+        WHERE c NOT IN (id_column, 'the_geom', 'the_geom_webmercator')
     ) INTO rest_of_cols;
 
     -- Create a view with homogeneous CDB fields

--- a/scripts-available/CDB_PG_Federated_Tables.sql
+++ b/scripts-available/CDB_PG_Federated_Tables.sql
@@ -185,7 +185,7 @@ BEGIN
     -- Get a list of columns excluding the id, geom and the_geom_webmercator
     SELECT ARRAY(
         SELECT quote_ident(c) FROM @extschema@.__ft_getcolumns(src_table) AS c
-        WHERE c NOT IN (id_column, geom_column, webmercator_column)
+        WHERE c NOT IN (id_column, geom_column, webmercator_column, 'cartodb_id', 'the_geom', 'the_geom_webmercator')
     ) INTO rest_of_cols;
 
     -- Figure out whether a ST_Transform to 4326 is needed or not
@@ -274,7 +274,7 @@ BEGIN
     -- Get a list of columns excluding the id
     SELECT ARRAY(
         SELECT quote_ident(c) FROM @extschema@.__ft_getcolumns(src_table) AS c
-        WHERE c NOT IN (id_column, 'the_geom', 'the_geom_webmercator')
+        WHERE c NOT IN (id_column, 'cartodb_id', 'the_geom', 'the_geom_webmercator')
     ) INTO rest_of_cols;
 
     -- Create a view with homogeneous CDB fields

--- a/test/extension/test.sh
+++ b/test/extension/test.sh
@@ -833,6 +833,18 @@ EOF
                           )"
     sql cdb_testmember_1 "SELECT cartodb_id, another_field, the_geom, the_geom_webmercator FROM remote_table5;" should '1|patata||'
 
+    # It shall work without any geometries, even if the table has the_geom or the_geom_webmercator
+    DATABASE=fdw_target sql postgres 'CREATE TABLE test_fdw.remote_table6 (id int,  another_field text, the_geom geometry(Geometry,4326), the_geom_webmercator geometry(Geometry,3857));'
+    DATABASE=fdw_target sql postgres 'GRANT SELECT ON TABLE test_fdw.remote_table6 TO fdw_user;'
+    DATABASE=fdw_target sql postgres "INSERT INTO test_fdw.remote_table6 VALUES (1, 'patata', cartodb.CDB_latLng(0,0), ST_Transform(cartodb.CDB_LatLng(0, 0), 3857));"
+    sql cdb_testmember_1 "SELECT cartodb.CDB_SetUp_PG_Federated_Table(
+                              'my_server',
+                              'test_fdw',
+                              'remote_table6',
+                              'id'
+                          )"
+    sql cdb_testmember_1 "SELECT cartodb_id, another_field, the_geom, the_geom_webmercator FROM remote_table6;" should '1|patata||'
+
 
     # Tear down
     DATABASE=fdw_target sql postgres 'REVOKE ALL ON ALL TABLES IN SCHEMA test_fdw FROM fdw_user;'

--- a/test/extension/test.sh
+++ b/test/extension/test.sh
@@ -845,6 +845,18 @@ EOF
                           )"
     sql cdb_testmember_1 "SELECT cartodb_id, another_field, the_geom, the_geom_webmercator FROM remote_table6;" should '1|patata||'
 
+    # similar case, when providing a geom column, with potential clashing of the_geom_webmercator
+    sql cdb_testmember_1 "DROP VIEW remote_table6;"
+    sql cdb_testmember_1 "DROP FOREIGN TABLE cdb_fdw_my_server.remote_table6;"
+    sql cdb_testmember_1 "SELECT cartodb.CDB_SetUp_PG_Federated_Table(
+                              'my_server',
+                              'test_fdw',
+                              'remote_table6',
+                              'id',
+                              'the_geom'
+                          )"
+    sql cdb_testmember_1 "SELECT cartodb_id, another_field, ST_AsText(the_geom) FROM remote_table6;" should '1|patata|POINT(0 0)'
+
 
     # Tear down
     DATABASE=fdw_target sql postgres 'REVOKE ALL ON ALL TABLES IN SCHEMA test_fdw FROM fdw_user;'


### PR DESCRIPTION
Fix for CDB_SetUp_PG_Federated_Table('server', 'schema', 'table', 'id)
when the table contains the_geom and/or the_geom_webmercator columns
but they are not part of the input.

Otherwise it fails with

    ERROR:  column "the_geom" specified more than once