### PR TITLE
PG Federated Tables: fix quoting of input NAME params

### DIFF
--- a/scripts-available/CDB_PG_Federated_Tables.sql
+++ b/scripts-available/CDB_PG_Federated_Tables.sql
@@ -173,7 +173,7 @@ BEGIN
 
     -- Import the foreign table
     PERFORM @extschema@.CDB_SetUp_User_PG_FDW_Table(server_alias, schema_name, table_name);
-    src_table := format('%s.%s', fdw_objects_name, table_name);
+    src_table := format('%I.%I', fdw_objects_name, table_name);
 
     -- Check id_column is numeric
     IF NOT @extschema@.__ft_is_numeric(src_table, id_column) THEN

--- a/scripts-available/CDB_PG_Federated_Tables.sql
+++ b/scripts-available/CDB_PG_Federated_Tables.sql
@@ -93,6 +93,10 @@ AS $$
 $$ LANGUAGE SQL;
 
 
+-- Drop legacy functions (this is just needed during development)
+DROP FUNCTION IF EXISTS cartodb.cdb_setup_pg_federated_table(server_alias name, schema_name name, table_name name, id_column name);
+DROP FUNCTION IF EXISTS cartodb.cdb_setup_pg_federated_table(server_alias name, schema_name name, table_name name, id_column name, geom_column name);
+DROP FUNCTION IF EXISTS cartodb.cdb_setup_pg_federated_table(server_alias text, schema_name name, table_name name, id_column name, geom_column name, webmercator_column name);
 
 --------------------------------------------------------------------------------
 -- Public functions

--- a/test/extension/test.sh
+++ b/test/extension/test.sh
@@ -901,6 +901,20 @@ EOF
                           )"
     sql cdb_testmember_1 'SELECT * FROM "Remote table10";' should '1|||42'
 
+    # same as above with geom and mercator cols
+    DATABASE=fdw_target sql postgres 'CREATE TABLE test_fdw."Remote table11" ("my id" int, "my value" int, "my geom" geometry(Geometry,4326), "my mercator" geometry(Geometry,3857));'
+    DATABASE=fdw_target sql postgres 'INSERT INTO test_fdw."Remote table11" VALUES (1, 42, cartodb.CDB_LatLng(0,0));'
+    DATABASE=fdw_target sql postgres 'GRANT SELECT ON ALL TABLES IN SCHEMA test_fdw TO fdw_user;'
+    sql cdb_testmember_1 "SELECT cartodb.CDB_SetUp_PG_Federated_Table(
+                              'my_server',
+                              'test_fdw',
+                              'Remote table11',
+                              'my id',
+                              'my geom',
+                              'my mercator'
+                          )"
+    sql cdb_testmember_1 'SELECT cartodb_id, ST_AsText(the_geom), the_geom_webmercator, "my value" FROM "Remote table11";' should '1|POINT(0 0)||42'
+
 
     # Tear down
     DATABASE=fdw_target sql postgres 'REVOKE ALL ON ALL TABLES IN SCHEMA test_fdw FROM fdw_user;'

--- a/test/extension/test.sh
+++ b/test/extension/test.sh
@@ -888,6 +888,19 @@ EOF
                               'webmercator'
                           )"
 
+    # It shall work with columns with especial characters (those that
+    # require quoting)
+    DATABASE=fdw_target sql postgres 'CREATE TABLE test_fdw."Remote table10" ("my id" int, "my value" int);'
+    DATABASE=fdw_target sql postgres 'INSERT INTO test_fdw."Remote table10" VALUES (1, 42);'
+    DATABASE=fdw_target sql postgres 'GRANT SELECT ON ALL TABLES IN SCHEMA test_fdw TO fdw_user;'
+    sql cdb_testmember_1 "SELECT cartodb.CDB_SetUp_PG_Federated_Table(
+                              'my_server',
+                              'test_fdw',
+                              'Remote table10',
+                              'my id'
+                          )"
+    sql cdb_testmember_1 'SELECT * FROM "Remote table10";' should '1|||42'
+
 
     # Tear down
     DATABASE=fdw_target sql postgres 'REVOKE ALL ON ALL TABLES IN SCHEMA test_fdw FROM fdw_user;'


### PR DESCRIPTION
NAME params require quoting, as opposed to REGCLASS, as they are
automatically checked on input and quoted on output.

We cannot use REGCLASS on inputs cause the system catalog does not
contain the foreign objects yet.

OTOH we have to be careful not to quote twice.

E.g:

```sql
-- The bugfix
SELECT format('%s', 'my name'::NAME); -- => my name
SELECT format('%I', 'my name'::NAME); -- => "my name"

-- REGCLASS type checks the system catalog underneath
SELECT format('%s', 'this_does_not_exist'::regclass); -- => ERROR:  relation "this_does_not_exist" does not exist

-- Table names with spaces
CREATE TABLE "name with spaces"();
SELECT format('%s', 'name with spaces'::regclass);   -- => ERROR:  invalid name syntax
SELECT format('%s', '"name with spaces"'::regclass); -- => "name with spaces"

-- Double-quoting issues
SELECT format('%I', '"name with spaces"'::regclass); -- => """name with spaces"""
SELECT * FROM """name with spaces""";      -- => ERROR:  relation ""name with spaces"" does not exist
SELECT '"""name with spaces"""'::regclass; -- => ERROR:  relation ""name with spaces"" does not exist
```