### PR TITLE
PG federated tables listing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -199,7 +199,7 @@ legacy_tests: legacy_regress $(EXTENSION)--unpackaged--$(EXTVERSION).sql
 
 PGREGRESS := $(shell dirname `$(PG_CONFIG) --pgxs`)/../../src/test/regress/pg_regress
 regress: legacy_tests
-	$(PGREGRESS) --inputdir=./ --bindir='/usr/bin'    --dbname=contrib_regression $(REGRESS)
+	$(PGREGRESS) --inputdir=./ --dbname=contrib_regression $(REGRESS)
 
 installcheck: legacy_tests test_extension_new test_organization
 

--- a/scripts-available/CDB_Federated_Tables_Listing.sql
+++ b/scripts-available/CDB_Federated_Tables_Listing.sql
@@ -15,8 +15,34 @@ LANGUAGE SQL VOLATILE PARALLEL UNSAFE;
 CREATE OR REPLACE FUNCTION @extschema@.__fdw_pg_list_foreign_schemas(remote_server name)
 RETURNS TABLE(remote_schema name)
 AS $$
+DECLARE
+    fdw_objects_name name := @extschema@.__CDB_User_FDW_Object_Names(remote_server);
 BEGIN
-    RAISE WARNING 'To be implemented';
+    -- Import schemata from the information schema
+    --
+    -- "The view schemata contains all schemas in the current database
+    -- that the current user has access to (by way of being the owner
+    -- or having some privilege)."
+    -- See https://www.postgresql.org/docs/11/infoschema-schemata.html
+    --
+    -- "The information schema is defined in the SQL standard and can
+    -- therefore be expected to be portable and remain stable"
+    -- See https://www.postgresql.org/docs/11/information-schema.html
+
+    -- Create local target schema if it does not exists
+    IF NOT EXISTS (SELECT * FROM pg_namespace WHERE nspname = fdw_objects_name) THEN
+       EXECUTE format('CREATE SCHEMA %I', fdw_objects_name);
+    END IF;
+
+    -- Import the foreign schemata if not done
+    IF NOT EXISTS (SELECT * FROM pg_class
+                   WHERE relnamespace = (SELECT oid FROM pg_namespace WHERE nspname = fdw_objects_name)
+                      AND relname = 'schemata') THEN
+        EXECUTE format('IMPORT FOREIGN SCHEMA information_schema LIMIT TO (schemata) FROM SERVER %I INTO %I', remote_server, fdw_objects_name);
+    END IF;
+
+    -- Return the result we're interested in
+    RETURN QUERY EXECUTE format('SELECT schema_name::name AS remote_schema FROM %I.schemata', fdw_objects_name);
 END
 $$
 LANGUAGE PLPGSQL VOLATILE PARALLEL UNSAFE;
@@ -34,10 +60,9 @@ CREATE OR REPLACE FUNCTION @extschema@.CDB_Federated_Server_List_Remote_Schemas(
 RETURNS TABLE(remote_schema name)
 AS $$
 DECLARE
-    server_type name;
+    server_type name := @extschema@.__fdw_server_type(remote_server);
 BEGIN
     -- Check the type of the server, fail if not implemented
-    server_type := @extschema@.__fdw_server_type(remote_server);
     CASE server_type
     WHEN 'postgres_fdw' THEN
         RETURN QUERY SELECT @extschema@.__fdw_pg_list_foreign_schemas(remote_server);

--- a/scripts-available/CDB_Federated_Tables_Listing.sql
+++ b/scripts-available/CDB_Federated_Tables_Listing.sql
@@ -1,0 +1,62 @@
+--------------------------------------------------------------------------------
+-- Private functions
+--------------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION @extschema@.__fdw_server_type(remote_server name)
+RETURNS name
+AS $$
+    SELECT f.fdwname
+        FROM pg_foreign_server s
+        JOIN pg_foreign_data_wrapper f ON s.srvfdw = f.oid
+        WHERE s.srvname = remote_server;
+$$
+LANGUAGE SQL VOLATILE PARALLEL UNSAFE;
+
+
+CREATE OR REPLACE FUNCTION @extschema@.__fdw_pg_list_foreign_schemas(remote_server name)
+RETURNS TABLE(remote_schema name)
+AS $$
+BEGIN
+    RAISE WARNING 'To be implemented';
+END
+$$
+LANGUAGE PLPGSQL VOLATILE PARALLEL UNSAFE;
+
+
+--------------------------------------------------------------------------------
+-- Public functions
+--------------------------------------------------------------------------------
+
+--
+-- List remote schemas in a federated server that the current user has
+-- access to.
+--
+CREATE OR REPLACE FUNCTION @extschema@.CDB_Federated_Server_List_Remote_Schemas(remote_server name)
+RETURNS TABLE(remote_schema name)
+AS $$
+DECLARE
+    server_type name;
+BEGIN
+    -- Check the type of the server, fail if not implemented
+    server_type := @extschema@.__fdw_server_type(remote_server);
+    CASE server_type
+    WHEN 'postgres_fdw' THEN
+        RETURN QUERY SELECT @extschema@.__fdw_pg_list_foreign_schemas(remote_server);
+    ELSE
+        RAISE EXCEPTION 'Not implemented server type % for remote server %', server_type, remote_server;
+    END CASE;
+END
+$$
+LANGUAGE PLPGSQL VOLATILE PARALLEL UNSAFE;
+
+
+--
+-- List remote tables in a federated server that the current user has
+-- access to.
+--
+CREATE OR REPLACE FUNCTION @extschema@.CDB_Federated_Server_List_Remote_Tables(remote_server name, remote_schema name)
+RETURNS TABLE(remote_table name, registered boolean)
+AS $$
+BEGIN
+END
+$$
+LANGUAGE PLPGSQL VOLATILE PARALLEL UNSAFE;

--- a/scripts-available/CDB_Federated_Tables_Listing.sql
+++ b/scripts-available/CDB_Federated_Tables_Listing.sql
@@ -48,6 +48,40 @@ $$
 LANGUAGE PLPGSQL VOLATILE PARALLEL UNSAFE;
 
 
+CREATE OR REPLACE FUNCTION @extschema@.__fdw_pg_list_foreign_tables(remote_server name, remote_schema name)
+RETURNS TABLE(remote_table name)
+AS $func$
+DECLARE
+    fdw_objects_name name := @extschema@.__CDB_User_FDW_Object_Names(remote_server);
+BEGIN
+    -- Import `tables` from the information schema
+    --
+    -- "The view tables contains all tables and views defined in the
+    -- current database. Only those tables and views are shown that
+    -- the current user has access to (by way of being the owner or
+    -- having some privilege)."
+    -- https://www.postgresql.org/docs/11/infoschema-tables.html
+
+    -- Create local target schema if it does not exists
+    IF NOT EXISTS (SELECT * FROM pg_namespace WHERE nspname = fdw_objects_name) THEN
+        EXECUTE format('CREATE SCHEMA %I', fdw_objects_name);
+    END IF;
+
+    -- Import the foreign `tables` if not done
+    IF NOT EXISTS (SELECT * FROM pg_class
+                   WHERE relnamespace = (SELECT oid FROM pg_namespace WHERE nspname = fdw_objects_name)
+                      AND relname = 'tables') THEN
+        EXECUTE format('IMPORT FOREIGN SCHEMA information_schema LIMIT TO (tables) FROM SERVER %I INTO %I', remote_server, fdw_objects_name);
+    END IF;
+
+    -- Return the result we're interested in
+    -- Note: in this context, schema names are not to be quoted
+    RETURN QUERY EXECUTE format($q$SELECT table_name::name AS remote_table FROM %I.tables WHERE table_schema = '%s'$q$, fdw_objects_name, remote_schema);
+END
+$func$
+LANGUAGE PLPGSQL VOLATILE PARALLEL UNSAFE;
+
+
 --------------------------------------------------------------------------------
 -- Public functions
 --------------------------------------------------------------------------------
@@ -79,9 +113,18 @@ LANGUAGE PLPGSQL VOLATILE PARALLEL UNSAFE;
 -- access to.
 --
 CREATE OR REPLACE FUNCTION @extschema@.CDB_Federated_Server_List_Remote_Tables(remote_server name, remote_schema name)
-RETURNS TABLE(remote_table name, registered boolean)
+RETURNS TABLE(remote_table name)
 AS $$
+DECLARE
+    server_type name := @extschema@.__fdw_server_type(remote_server);
 BEGIN
+    -- Check the type of the server, fail if not implemented
+    CASE server_type
+    WHEN 'postgres_fdw' THEN
+        RETURN QUERY SELECT @extschema@.__fdw_pg_list_foreign_tables(remote_server, remote_schema);
+    ELSE
+        RAISE EXCEPTION 'Not implemented server type % for remote server %', server_type, remote_server;
+    END CASE;
 END
 $$
 LANGUAGE PLPGSQL VOLATILE PARALLEL UNSAFE;

--- a/scripts-enabled/257-CDB_Federated_Tables_Listing.sql
+++ b/scripts-enabled/257-CDB_Federated_Tables_Listing.sql
@@ -1,0 +1,1 @@
+../scripts-available/CDB_Federated_Tables_Listing.sql

--- a/test/CDB_Federate_Tables_Listing_Test.sql
+++ b/test/CDB_Federate_Tables_Listing_Test.sql
@@ -1,0 +1,89 @@
+-- ===================================================================
+-- create FDW objects
+-- ===================================================================
+\set QUIET on
+CREATE EXTENSION IF NOT EXISTS postgres_fdw;
+
+CREATE SERVER testserver1 FOREIGN DATA WRAPPER postgres_fdw;
+DO $d$
+    BEGIN
+        EXECUTE $$CREATE SERVER loopback FOREIGN DATA WRAPPER postgres_fdw
+            OPTIONS (dbname '$$||current_database()||$$',
+                     port '$$||current_setting('port')||$$'
+            )$$;
+        EXECUTE $$CREATE SERVER loopback2 FOREIGN DATA WRAPPER postgres_fdw
+            OPTIONS (dbname '$$||current_database()||$$',
+                     port '$$||current_setting('port')||$$'
+            )$$;
+    END;
+$d$;
+
+CREATE USER MAPPING FOR CURRENT_USER SERVER loopback;
+CREATE USER MAPPING FOR CURRENT_USER SERVER loopback2;
+
+-- ===================================================================
+-- create objects used through FDW loopback server
+-- ===================================================================
+CREATE TYPE user_enum AS ENUM ('foo', 'bar', 'buz');
+CREATE SCHEMA "S 1";
+CREATE TABLE "S 1"."T 1" (
+	"C 1" int NOT NULL,
+	c2 int NOT NULL,
+	c3 text,
+	c4 timestamptz,
+	c5 timestamp,
+	c6 varchar(10),
+	c7 char(10),
+	c8 user_enum,
+	CONSTRAINT t1_pkey PRIMARY KEY ("C 1")
+);
+CREATE TABLE "S 1"."T 2" (
+	c1 int NOT NULL,
+	c2 text,
+	CONSTRAINT t2_pkey PRIMARY KEY (c1)
+);
+CREATE TABLE "S 1"."T 3" (
+	c1 int NOT NULL,
+	c2 int NOT NULL,
+	c3 text,
+	CONSTRAINT t3_pkey PRIMARY KEY (c1)
+);
+CREATE TABLE "S 1"."T 4" (
+	c1 int NOT NULL,
+	c2 int NOT NULL,
+	c3 text,
+	CONSTRAINT t4_pkey PRIMARY KEY (c1)
+);
+
+-- Disable autovacuum for these tables to avoid unexpected effects of that
+ALTER TABLE "S 1"."T 1" SET (autovacuum_enabled = 'false');
+ALTER TABLE "S 1"."T 2" SET (autovacuum_enabled = 'false');
+ALTER TABLE "S 1"."T 3" SET (autovacuum_enabled = 'false');
+ALTER TABLE "S 1"."T 4" SET (autovacuum_enabled = 'false');
+\set QUIET off
+
+
+-- ===================================================================
+-- Test the listing functions
+-- ===================================================================
+SELECT cartodb.CDB_Federated_Server_List_Remote_Schemas(remote_server => 'loopback');
+
+
+-- ===================================================================
+-- Cleanup
+-- ===================================================================
+\set QUIET on
+DROP TABLE "S 1". "T 1";
+DROP TABLE "S 1". "T 2";
+DROP TABLE "S 1". "T 3";
+DROP TABLE "S 1". "T 4";
+
+DROP SCHEMA "S 1";
+DROP TYPE user_enum;
+
+DROP USER MAPPING FOR CURRENT_USER SERVER loopback;
+DROP USER MAPPING FOR CURRENT_USER SERVER loopback2;
+
+DROP SERVER loopback;
+DROP SERVER loopback2;
+\set QUIET off

--- a/test/CDB_Federate_Tables_Listing_Test.sql
+++ b/test/CDB_Federate_Tables_Listing_Test.sql
@@ -2,6 +2,7 @@
 -- create FDW objects
 -- ===================================================================
 \set QUIET on
+SET client_min_messages TO warning;
 CREATE EXTENSION IF NOT EXISTS postgres_fdw;
 
 CREATE SERVER testserver1 FOREIGN DATA WRAPPER postgres_fdw;
@@ -66,8 +67,10 @@ ALTER TABLE "S 1"."T 4" SET (autovacuum_enabled = 'false');
 -- ===================================================================
 -- Test the listing functions
 -- ===================================================================
-SELECT cartodb.CDB_Federated_Server_List_Remote_Schemas(remote_server => 'loopback');
-
+\echo 'Test CDB_Federated_Server_List_Remote_Schemas (sunny day)'
+SELECT * FROM cartodb.CDB_Federated_Server_List_Remote_Schemas(remote_server => 'loopback')
+    WHERE remote_schema NOT LIKE 'pg_%' -- Exclude toast and temp schemas
+    ORDER BY remote_schema;
 
 -- ===================================================================
 -- Cleanup
@@ -84,6 +87,6 @@ DROP TYPE user_enum;
 DROP USER MAPPING FOR CURRENT_USER SERVER loopback;
 DROP USER MAPPING FOR CURRENT_USER SERVER loopback2;
 
-DROP SERVER loopback;
-DROP SERVER loopback2;
+DROP SERVER loopback CASCADE;
+DROP SERVER loopback2 CASCADE;
 \set QUIET off

--- a/test/CDB_Federate_Tables_Listing_Test.sql
+++ b/test/CDB_Federate_Tables_Listing_Test.sql
@@ -79,6 +79,13 @@ SELECT * FROM cartodb.CDB_Federated_Server_List_Remote_Schemas(remote_server => 
 \echo 'Test listing of schemas from an unsupported server'
 SELECT * FROM cartodb.CDB_Federated_Server_List_Remote_Schemas(remote_server => 'pglog');
 
+\echo 'Test listing of remote tables (sunny day)'
+SELECT * FROM cartodb.CDB_Federated_Server_List_Remote_Tables(remote_server => 'loopback', remote_schema => 'S 1')
+    ORDER BY remote_table;
+
+\echo 'Test listing of remote tables from an unsupported server'
+SELECT * FROM cartodb.CDB_Federated_Server_List_Remote_Schemas(remote_server => 'pglog', remote_schema => 'foo');
+
 -- ===================================================================
 -- Cleanup
 -- ===================================================================

--- a/test/CDB_Federate_Tables_Listing_Test.sql
+++ b/test/CDB_Federate_Tables_Listing_Test.sql
@@ -84,7 +84,7 @@ SELECT * FROM cartodb.CDB_Federated_Server_List_Remote_Tables(remote_server => '
     ORDER BY remote_table;
 
 \echo 'Test listing of remote tables from an unsupported server'
-SELECT * FROM cartodb.CDB_Federated_Server_List_Remote_Schemas(remote_server => 'pglog', remote_schema => 'foo');
+SELECT * FROM cartodb.CDB_Federated_Server_List_Remote_Tables(remote_server => 'pglog', remote_schema => 'foo');
 
 -- ===================================================================
 -- Cleanup

--- a/test/CDB_Federate_Tables_Listing_Test.sql
+++ b/test/CDB_Federate_Tables_Listing_Test.sql
@@ -2,8 +2,10 @@
 -- create FDW objects
 -- ===================================================================
 \set QUIET on
+\set VERBOSITY terse
 SET client_min_messages TO warning;
 CREATE EXTENSION IF NOT EXISTS postgres_fdw;
+CREATE EXTENSION IF NOT EXISTS file_fdw;
 
 CREATE SERVER testserver1 FOREIGN DATA WRAPPER postgres_fdw;
 DO $d$
@@ -18,6 +20,8 @@ DO $d$
             )$$;
     END;
 $d$;
+
+CREATE SERVER pglog FOREIGN DATA WRAPPER file_fdw;
 
 CREATE USER MAPPING FOR CURRENT_USER SERVER loopback;
 CREATE USER MAPPING FOR CURRENT_USER SERVER loopback2;
@@ -67,10 +71,13 @@ ALTER TABLE "S 1"."T 4" SET (autovacuum_enabled = 'false');
 -- ===================================================================
 -- Test the listing functions
 -- ===================================================================
-\echo 'Test CDB_Federated_Server_List_Remote_Schemas (sunny day)'
+\echo 'Test listing of remote schemas (sunny day)'
 SELECT * FROM cartodb.CDB_Federated_Server_List_Remote_Schemas(remote_server => 'loopback')
     WHERE remote_schema NOT LIKE 'pg_%' -- Exclude toast and temp schemas
     ORDER BY remote_schema;
+
+\echo 'Test listing of schemas from an unsupported server'
+SELECT * FROM cartodb.CDB_Federated_Server_List_Remote_Schemas(remote_server => 'pglog');
 
 -- ===================================================================
 -- Cleanup

--- a/test/CDB_Federate_Tables_Listing_Test_expect
+++ b/test/CDB_Federate_Tables_Listing_Test_expect
@@ -1,0 +1,5 @@
+Test CDB_Federated_Server_List_Remote_Schemas (sunny day)
+S 1
+cartodb
+information_schema
+public

--- a/test/CDB_Federate_Tables_Listing_Test_expect
+++ b/test/CDB_Federate_Tables_Listing_Test_expect
@@ -1,5 +1,7 @@
-Test CDB_Federated_Server_List_Remote_Schemas (sunny day)
+Test listing of remote schemas (sunny day)
 S 1
 cartodb
 information_schema
 public
+Test listing of schemas from an unsupported server
+ERROR:  Not implemented server type file_fdw for remote server pglog

--- a/test/CDB_Federate_Tables_Listing_Test_expect
+++ b/test/CDB_Federate_Tables_Listing_Test_expect
@@ -11,4 +11,4 @@ T 2
 T 3
 T 4
 Test listing of remote tables from an unsupported server
-ERROR:  function cartodb.cdb_federated_server_list_remote_schemas(remote_server => unknown, remote_schema => unknown) does not exist at character 15
+ERROR:  Not implemented server type file_fdw for remote server pglog

--- a/test/CDB_Federate_Tables_Listing_Test_expect
+++ b/test/CDB_Federate_Tables_Listing_Test_expect
@@ -5,3 +5,10 @@ information_schema
 public
 Test listing of schemas from an unsupported server
 ERROR:  Not implemented server type file_fdw for remote server pglog
+Test listing of remote tables (sunny day)
+T 1
+T 2
+T 3
+T 4
+Test listing of remote tables from an unsupported server
+ERROR:  function cartodb.cdb_federated_server_list_remote_schemas(remote_server => unknown, remote_schema => unknown) does not exist at character 15


### PR DESCRIPTION
This implements listing of remote schemas and tables, from a federated server, registered or not.

A few important remarks:
- It does not depend on any extra extension (e.g `dblink` nor patches in `postgres_fdw`)
- It imports a couple foreign views into the local schema given by `__CDB_User_FDW_Object_Names()`. The target schema may be changed to avoid conflicts.
- Potentially they may return more info, such as the the [`table_type`](https://www.postgresql.org/docs/11/infoschema-tables.html). I stuck to the essence until we clear out some doubts
- IMO there should be functions to list registered tables and to list ALL foreign tables (registered or not). API-wise this may be solved by adding a column `registered bool` IF we have a solid convention to place federated objects and at the expense of complexity.

@Algunenano at this point I'm more concerned about the interface and the relations between the functions than in the implementation. What do you think?

Thanks!