### PR TITLE
Federated diagnostics latency

### DIFF
--- a/scripts-available/CDB_FederatedServerDiagnostics.sql
+++ b/scripts-available/CDB_FederatedServerDiagnostics.sql
@@ -130,7 +130,7 @@ LANGUAGE SQL VOLATILE PARALLEL UNSAFE;
 --
 CREATE OR REPLACE FUNCTION @extschema@.__CDB_FS_TCP_Network_Latency(
     host text,
-    port integer DEFAULT 5432,
+    port integer,
     timeout_seconds float DEFAULT 5.0
 )
 RETURNS float

--- a/scripts-available/CDB_FederatedServerDiagnostics.sql
+++ b/scripts-available/CDB_FederatedServerDiagnostics.sql
@@ -146,7 +146,7 @@ AS $$
 
     plan = plpy.prepare("SELECT @extschema@.__CDB_FS_Foreign_Server_Port_PG($1) AS port", ['name'])
     rv = plpy.execute(plan, [server_internal], 1)
-    port = rv[0]['port']
+    port = rv[0]['port'] or 5432
 
     n_errors = 0
     samples = []

--- a/scripts-available/CDB_FederatedServerDiagnostics.sql
+++ b/scripts-available/CDB_FederatedServerDiagnostics.sql
@@ -146,14 +146,14 @@ AS $$
     rv = plpy.execute(plan, [server_internal], 1)
     port = rv[0]['port']
 
-    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    s.settimeout(timeout_seconds)
-
-    t_start = timer()
-    samples = []
-    n_errors = 0
-
     for i in xrange(n_samples):
+        s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        s.settimeout(timeout_seconds)
+
+        t_start = timer()
+        samples = []
+        n_errors = 0
+
         try:
             s.connect((host, int(port)))
             t_stop = timer()

--- a/scripts-available/CDB_FederatedServerDiagnostics.sql
+++ b/scripts-available/CDB_FederatedServerDiagnostics.sql
@@ -188,13 +188,13 @@ DECLARE
     remote_server_version  text := @extschema@.__CDB_FS_Foreign_Server_Version_PG(server_internal);
     remote_postgis_version text := @extschema@.__CDB_FS_Foreign_PostGIS_Version_PG(server_internal);
     remote_server_options jsonb := @extschema@.__CDB_FS_Foreign_Server_Options_PG(server_internal);
-    remote_server_latency float := @extschema@.__CDB_FS_Foreign_Server_Latency_PG(server_internal);
+    remote_server_latency_ms float := @extschema@.__CDB_FS_Foreign_Server_Latency_PG(server_internal);
 BEGIN
     RETURN jsonb_build_object(
         'server_version', remote_server_version,
         'postgis_version', remote_postgis_version,
         'server_options', remote_server_options,
-        'server_latency', remote_server_latency
+        'server_latency_ms', remote_server_latency_ms
     );
 END
 $$

--- a/scripts-available/CDB_FederatedServerDiagnostics.sql
+++ b/scripts-available/CDB_FederatedServerDiagnostics.sql
@@ -171,21 +171,25 @@ AS $$
         plpy.debug('TCP connection %s:%d time=%.2f ms' % (host, port, t_connect))
         samples.append(t_connect)
 
-    # --stats
-    n = len(samples)
-    mean = sum(samples) / n
-    var = sum([ (x - mean)**2 for x in samples ]) / (n-1)
-    stdev = math.sqrt(var)
-
-    ret = {
+    stats = {
         'n_samples': n_samples,
         'n_errors': n_errors,
-        'avg': round(mean, 3),
-        'min': round(min(samples), 3),
-        'max': round(max(samples), 3),
-        'stdev': round(stdev, 3)
     }
-    return json.dumps(ret)
+    n = len(samples)
+    if n >= 1:
+        mean = sum(samples) / n
+        stats.update({
+            'avg': round(mean, 3),
+            'min': round(min(samples), 3),
+            'max': round(max(samples), 3)
+        })
+    if n >= 2:
+        var = sum([ (x - mean)**2 for x in samples ]) / (n-1)
+        stdev = math.sqrt(var)
+        stats.update({
+            'stdev': round(stdev, 3)
+        })
+    return json.dumps(stats)
 $$
 LANGUAGE plpythonu VOLATILE PARALLEL UNSAFE;
 

--- a/scripts-available/CDB_FederatedServerDiagnostics.sql
+++ b/scripts-available/CDB_FederatedServerDiagnostics.sql
@@ -146,7 +146,7 @@ AS $$
     rv = plpy.execute(plan, [server_internal], 1)
     port = rv[0]['port']
 
-    for i in xrange(n_samples):
+    for i in range(n_samples):
         s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         s.settimeout(timeout_seconds)
 

--- a/scripts-available/CDB_FederatedServerDiagnostics.sql
+++ b/scripts-available/CDB_FederatedServerDiagnostics.sql
@@ -104,12 +104,12 @@ LANGUAGE SQL VOLATILE PARALLEL UNSAFE;
 CREATE OR REPLACE FUNCTION @extschema@.__CDB_FS_Foreign_Server_Host_PG(server_internal name)
 RETURNS text
 AS $$
-BEGIN
-    -- TODO: implement
-    RETURN 'localhost';
-END
+    SELECT option_value FROM (
+        SELECT (pg_options_to_table(srvoptions)).*
+        FROM pg_foreign_server WHERE srvname = server_internal
+    ) AS opt WHERE opt.option_name = 'host';
 $$
-LANGUAGE PLPGSQL VOLATILE PARALLEL UNSAFE;
+LANGUAGE SQL VOLATILE PARALLEL UNSAFE;
 
 
 --

--- a/scripts-available/CDB_FederatedServerDiagnostics.sql
+++ b/scripts-available/CDB_FederatedServerDiagnostics.sql
@@ -158,8 +158,8 @@ AS $$
             s.connect((host, int(port)))
             t_stop = timer()
             s.shutdown(socket.SHUT_RD)
-        except (socket.timeout, OSError, socket.error), ex:
-            #-- TODO uncomment & fix: plpy.warning('could not connect to server %s:%d, %s' % (host, port, str(ex)))
+        except (socket.timeout, OSError, socket.error) as ex:
+            plpy.warning('could not connect to server %s:%d, %s' % (host, port, str(ex)))
             n_errors += 1
         finally:
             s.close()

--- a/scripts-available/CDB_FederatedServerDiagnostics.sql
+++ b/scripts-available/CDB_FederatedServerDiagnostics.sql
@@ -97,14 +97,57 @@ AS $$
 $$
 LANGUAGE SQL VOLATILE PARALLEL UNSAFE;
 
+
+--
+-- Get a foreign PG server hostname from the catalog
+--
+CREATE OR REPLACE FUNCTION @extschema@.__CDB_FS_Foreign_Server_Host_PG(server_internal name)
+RETURNS text
+AS $$
+BEGIN
+    -- TODO: implement
+    RETURN 'localhost';
+END
+$$
+LANGUAGE PLPGSQL VOLATILE PARALLEL UNSAFE;
+
+
+--
+-- Get a foreign PG server port from the catalog
+--
+CREATE OR REPLACE FUNCTION @extschema@.__CDB_FS_Foreign_Server_Port_PG(server_internal name)
+RETURNS integer
+AS $$
+BEGIN
+    -- TODO: implement
+    RETURN 5432;
+END
+$$
+LANGUAGE PLPGSQL VOLATILE PARALLEL UNSAFE;
+
+--
+-- Get one measure of network latency to a remote TCP server
+CREATE OR REPLACE FUNCTION @extschema@.__CDB_FS_TCP_Network_Latency(host text, port integer)
+RETURNS float
+AS $$
+  #--TODO implement
+  return 0.0
+$$
+LANGUAGE plpythonu VOLATILE PARALLEL UNSAFE;
+
 --
 -- Get the network latency to a remote PG server
 --
 CREATE OR REPLACE FUNCTION @extschema@.__CDB_FS_Foreign_Server_Latency_PG(server_internal name)
 RETURNS float
 AS $$
+DECLARE
+    remote_server_host text := @extschema@.__CDB_FS_Foreign_Server_Host_PG(server_internal);
+    remote_server_port integer := @extschema@.__CDB_FS_Foreign_Server_Port_PG(server_internal); -- TODO: best type for ports
+    latency float;
 BEGIN
-    RETURN 0.0;
+    latency := @extschema@.__CDB_FS_TCP_Network_Latency(host => remote_server_host, port => remote_server_port);
+    RETURN latency;
 END
 $$
 LANGUAGE PLPGSQL VOLATILE PARALLEL UNSAFE;

--- a/scripts-available/CDB_FederatedServerDiagnostics.sql
+++ b/scripts-available/CDB_FederatedServerDiagnostics.sql
@@ -159,7 +159,7 @@ AS $$
             t_stop = timer()
             s.shutdown(socket.SHUT_RD)
         except (socket.timeout, OSError, socket.error), ex:
-            plpy.warning('could not connect to server %s:%d, %s' % (host, port, str(ex)))
+            #-- TODO uncomment & fix: plpy.warning('could not connect to server %s:%d, %s' % (host, port, str(ex)))
             n_errors += 1
         finally:
             s.close()

--- a/scripts-available/CDB_FederatedServerDiagnostics.sql
+++ b/scripts-available/CDB_FederatedServerDiagnostics.sql
@@ -151,6 +151,7 @@ AS $$
 
     t_start = timer()
     samples = []
+    n_errors = 0
 
     for i in xrange(n_samples):
         try:
@@ -159,13 +160,13 @@ AS $$
             s.shutdown(socket.SHUT_RD)
         except (socket.timeout, OSError, socket.error), ex:
             plpy.warning('could not connect to server %s:%d, %s' % (host, port, str(ex)))
-            samples.append(None)
+            n_errors += 1
 
         t_connect = (t_stop - t_start) * 1000.0
         plpy.debug('TCP connection %s:%d time=%.2f ms' % (host, port, t_connect))
         samples.append(t_connect)
 
-    return sum(samples) / n_samples
+    return sum(samples) / len(samples)
 $$
 LANGUAGE plpythonu VOLATILE PARALLEL UNSAFE;
 

--- a/scripts-available/CDB_FederatedServerDiagnostics.sql
+++ b/scripts-available/CDB_FederatedServerDiagnostics.sql
@@ -97,6 +97,18 @@ AS $$
 $$
 LANGUAGE SQL VOLATILE PARALLEL UNSAFE;
 
+--
+-- Get the network latency to a remote PG server
+--
+CREATE OR REPLACE FUNCTION @extschema@.__CDB_FS_Foreign_Server_Latency_PG(server_internal name)
+RETURNS float
+AS $$
+BEGIN
+    RETURN 0.0;
+END
+$$
+LANGUAGE PLPGSQL VOLATILE PARALLEL UNSAFE;
+
 
 --
 -- Collect and return diagnostics info from a remote PG into a jsonb
@@ -108,11 +120,13 @@ DECLARE
     remote_server_version  text := @extschema@.__CDB_FS_Foreign_Server_Version_PG(server_internal);
     remote_postgis_version text := @extschema@.__CDB_FS_Foreign_PostGIS_Version_PG(server_internal);
     remote_server_options jsonb := @extschema@.__CDB_FS_Foreign_Server_Options_PG(server_internal);
+    remote_server_latency float := @extschema@.__CDB_FS_Foreign_Server_Latency_PG(server_internal);
 BEGIN
     RETURN jsonb_build_object(
         'server_version', remote_server_version,
         'postgis_version', remote_postgis_version,
-        'server_options', remote_server_options
+        'server_options', remote_server_options,
+        'server_latency', remote_server_latency
     );
 END
 $$

--- a/scripts-available/CDB_FederatedServerDiagnostics.sql
+++ b/scripts-available/CDB_FederatedServerDiagnostics.sql
@@ -146,13 +146,14 @@ AS $$
     rv = plpy.execute(plan, [server_internal], 1)
     port = rv[0]['port']
 
+    n_errors = 0
+    samples = []
+
     for i in range(n_samples):
         s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         s.settimeout(timeout_seconds)
 
         t_start = timer()
-        samples = []
-        n_errors = 0
 
         try:
             s.connect((host, int(port)))

--- a/scripts-available/CDB_FederatedServerDiagnostics.sql
+++ b/scripts-available/CDB_FederatedServerDiagnostics.sql
@@ -118,12 +118,12 @@ LANGUAGE SQL VOLATILE PARALLEL UNSAFE;
 CREATE OR REPLACE FUNCTION @extschema@.__CDB_FS_Foreign_Server_Port_PG(server_internal name)
 RETURNS integer
 AS $$
-BEGIN
-    -- TODO: implement
-    RETURN 5432;
-END
+    SELECT option_value::integer FROM (
+        SELECT (pg_options_to_table(srvoptions)).*
+        FROM pg_foreign_server WHERE srvname = server_internal
+    ) AS opt WHERE opt.option_name = 'port';
 $$
-LANGUAGE PLPGSQL VOLATILE PARALLEL UNSAFE;
+LANGUAGE SQL VOLATILE PARALLEL UNSAFE;
 
 --
 -- Get one measure of network latency in ms to a remote TCP server

--- a/scripts-available/CDB_FederatedServerDiagnostics.sql
+++ b/scripts-available/CDB_FederatedServerDiagnostics.sql
@@ -161,6 +161,8 @@ AS $$
         except (socket.timeout, OSError, socket.error), ex:
             plpy.warning('could not connect to server %s:%d, %s' % (host, port, str(ex)))
             n_errors += 1
+        finally:
+            s.close()
 
         t_connect = (t_stop - t_start) * 1000.0
         plpy.debug('TCP connection %s:%d time=%.2f ms' % (host, port, t_connect))

--- a/test/CDB_FederatedServerDiagnostics.sql
+++ b/test/CDB_FederatedServerDiagnostics.sql
@@ -58,7 +58,8 @@ SELECT '1.5', cartodb.CDB_Federated_Server_Diagnostics(server => 'loopback') @> 
 SELECT '1.6', cartodb.CDB_Federated_Server_Diagnostics(server => 'loopback') @> '{"server_options": {"host": "localhost", "port": "@@PGPORT@@", "updatable": "false", "extensions": "postgis", "fetch_size": "1000", "use_remote_estimate": "true"}}'::jsonb;
 
 \echo '%% It returns the network latency to the remote server'
-SELECT '1.7', cartodb.CDB_Federated_Server_Diagnostics(server => 'loopback') @> '{"server_latency": 0.0}'::jsonb;
+SELECT '1.7', (cartodb.CDB_Federated_Server_Diagnostics(server => 'loopback')->'server_latency')::float > 0.0;
+SELECT '1.8', (cartodb.CDB_Federated_Server_Diagnostics(server => 'loopback')->'server_latency')::float < 1000.0;
 
 
 -- ===================================================================

--- a/test/CDB_FederatedServerDiagnostics.sql
+++ b/test/CDB_FederatedServerDiagnostics.sql
@@ -58,8 +58,8 @@ SELECT '1.5', cartodb.CDB_Federated_Server_Diagnostics(server => 'loopback') @> 
 SELECT '1.6', cartodb.CDB_Federated_Server_Diagnostics(server => 'loopback') @> '{"server_options": {"host": "localhost", "port": "@@PGPORT@@", "updatable": "false", "extensions": "postgis", "fetch_size": "1000", "use_remote_estimate": "true"}}'::jsonb;
 
 \echo '%% It returns the network latency to the remote server'
-SELECT '2.1', (cartodb.CDB_Federated_Server_Diagnostics(server => 'loopback')->'server_latency')::float > 0.0;
-SELECT '2.2', (cartodb.CDB_Federated_Server_Diagnostics(server => 'loopback')->'server_latency')::float < 1000.0;
+SELECT '2.1', (cartodb.CDB_Federated_Server_Diagnostics(server => 'loopback')->'server_latency_ms')::float > 0.0;
+SELECT '2.2', (cartodb.CDB_Federated_Server_Diagnostics(server => 'loopback')->'server_latency_ms')::float < 1000.0;
 
 \echo '%% It raises an error if the wrong port is provided'
 SELECT 'C2', cartodb.CDB_Federated_Server_Register_PG(server => 'wrong-port'::text, config => '{

--- a/test/CDB_FederatedServerDiagnostics.sql
+++ b/test/CDB_FederatedServerDiagnostics.sql
@@ -58,8 +58,8 @@ SELECT '1.5', cartodb.CDB_Federated_Server_Diagnostics(server => 'loopback') @> 
 SELECT '1.6', cartodb.CDB_Federated_Server_Diagnostics(server => 'loopback') @> '{"server_options": {"host": "localhost", "port": "@@PGPORT@@", "updatable": "false", "extensions": "postgis", "fetch_size": "1000", "use_remote_estimate": "true"}}'::jsonb;
 
 \echo '%% It returns the network latency to the remote server'
-SELECT '2.1', (cartodb.CDB_Federated_Server_Diagnostics(server => 'loopback')->'server_latency_ms')::float > 0.0;
-SELECT '2.2', (cartodb.CDB_Federated_Server_Diagnostics(server => 'loopback')->'server_latency_ms')::float < 1000.0;
+SELECT '2.1', (cartodb.CDB_Federated_Server_Diagnostics(server => 'loopback')->'server_latency_ms')::text::float > 0.0;
+SELECT '2.2', (cartodb.CDB_Federated_Server_Diagnostics(server => 'loopback')->'server_latency_ms')::text::float < 1000.0;
 
 \echo '%% It raises an error if the wrong port is provided'
 SELECT 'C2', cartodb.CDB_Federated_Server_Register_PG(server => 'wrong-port'::text, config => '{

--- a/test/CDB_FederatedServerDiagnostics.sql
+++ b/test/CDB_FederatedServerDiagnostics.sql
@@ -58,8 +58,22 @@ SELECT '1.5', cartodb.CDB_Federated_Server_Diagnostics(server => 'loopback') @> 
 SELECT '1.6', cartodb.CDB_Federated_Server_Diagnostics(server => 'loopback') @> '{"server_options": {"host": "localhost", "port": "@@PGPORT@@", "updatable": "false", "extensions": "postgis", "fetch_size": "1000", "use_remote_estimate": "true"}}'::jsonb;
 
 \echo '%% It returns the network latency to the remote server'
-SELECT '1.7', (cartodb.CDB_Federated_Server_Diagnostics(server => 'loopback')->'server_latency')::float > 0.0;
-SELECT '1.8', (cartodb.CDB_Federated_Server_Diagnostics(server => 'loopback')->'server_latency')::float < 1000.0;
+SELECT '2.1', (cartodb.CDB_Federated_Server_Diagnostics(server => 'loopback')->'server_latency')::float > 0.0;
+SELECT '2.2', (cartodb.CDB_Federated_Server_Diagnostics(server => 'loopback')->'server_latency')::float < 1000.0;
+
+\echo '%% It raises an error if the wrong port is provided'
+SELECT 'C2', cartodb.CDB_Federated_Server_Register_PG(server => 'wrong-port'::text, config => '{
+    "server": {
+        "host": "localhost",
+        "port": "12345"
+    },
+    "credentials": {
+        "username": "cdb_fs_tester",
+        "password": "cdb_fs_passwd"
+    }
+}'::jsonb);
+SELECT '3.0', cartodb.CDB_Federated_Server_Diagnostics(server => 'wrong-port');
+
 
 
 -- ===================================================================
@@ -67,6 +81,7 @@ SELECT '1.8', (cartodb.CDB_Federated_Server_Diagnostics(server => 'loopback')->'
 -- ===================================================================
 \set QUIET on
 SELECT 'D1', cartodb.CDB_Federated_Server_Unregister(server => 'loopback'::text);
+SELECT 'D2', cartodb.CDB_Federated_Server_Unregister(server => 'wrong-port'::text);
 -- Reconnect, using a new session in order to close FDW connections
 \connect
 DROP DATABASE cdb_fs_tester;

--- a/test/CDB_FederatedServerDiagnostics.sql
+++ b/test/CDB_FederatedServerDiagnostics.sql
@@ -57,6 +57,9 @@ SELECT '1.5', cartodb.CDB_Federated_Server_Diagnostics(server => 'loopback') @> 
 \echo '%% It returns the remote server options'
 SELECT '1.6', cartodb.CDB_Federated_Server_Diagnostics(server => 'loopback') @> '{"server_options": {"host": "localhost", "port": "@@PGPORT@@", "updatable": "false", "extensions": "postgis", "fetch_size": "1000", "use_remote_estimate": "true"}}'::jsonb;
 
+\echo '%% It returns the network latency to the remote server'
+SELECT '1.7', cartodb.CDB_Federated_Server_Diagnostics(server => 'loopback') @> '{"server_latency": 0.0}'::jsonb;
+
 
 -- ===================================================================
 -- Cleanup

--- a/test/CDB_FederatedServerDiagnostics_expect
+++ b/test/CDB_FederatedServerDiagnostics_expect
@@ -11,4 +11,7 @@ ERROR:  Server "doesNotExist" does not exist
 1.5|t
 %% It returns the remote server options
 1.6|t
+%% It returns the network latency to the remote server
+1.7|t
+1.8|t
 D1|

--- a/test/CDB_FederatedServerDiagnostics_expect
+++ b/test/CDB_FederatedServerDiagnostics_expect
@@ -1,4 +1,6 @@
 C1|
+C2|
+C3|
 %% It raises an error if the server does not exist
 ERROR:  Server "doesNotExist" does not exist
 %% It returns a jsonb object
@@ -18,7 +20,9 @@ ERROR:  Server "doesNotExist" does not exist
 %% Latency stats: stdev > 0
 2.3|t
 %% It raises an error if the wrong port is provided
-C2|
 ERROR:  could not connect to server "cdb_fs_wrong-port"
+%% Latency stats: can get them on default PG port 5432 when not provided
+2.4|t|t
 D1|
 D2|
+D3|

--- a/test/CDB_FederatedServerDiagnostics_expect
+++ b/test/CDB_FederatedServerDiagnostics_expect
@@ -12,6 +12,10 @@ ERROR:  Server "doesNotExist" does not exist
 %% It returns the remote server options
 1.6|t
 %% It returns the network latency to the remote server
-1.7|t
-1.8|t
+2.1|t
+2.2|t
+%% It raises an error if the wrong port is provided
+C2|
+ERROR:  could not connect to server "cdb_fs_wrong-port"
 D1|
+D2|

--- a/test/CDB_FederatedServerDiagnostics_expect
+++ b/test/CDB_FederatedServerDiagnostics_expect
@@ -11,9 +11,12 @@ ERROR:  Server "doesNotExist" does not exist
 1.5|t
 %% It returns the remote server options
 1.6|t
-%% It returns the network latency to the remote server
-2.1|t
-2.2|t
+%% It returns network latency stats to the remote server: min <= avg <= max
+2.1|t|t
+%% Latency stats: 0 <= min <= max <= 1000 ms (local connection)
+2.2|t|t
+%% Latency stats: stdev > 0
+2.3|t
 %% It raises an error if the wrong port is provided
 C2|
 ERROR:  could not connect to server "cdb_fs_wrong-port"


### PR DESCRIPTION
Add latency measurement to diagnostics function. E.g:

```sql
SELECT jsonb_pretty(cartodb.CDB_Federated_Server_Diagnostics(server => 'loopback'));
                jsonb_pretty                 
---------------------------------------------
 {                                          +
     "server_options": {                    +
         "host": "localhost",               +
         "port": "5432",                    +
         "updatable": "false",              +
         "extensions": "postgis",           +
         "fetch_size": "1000",              +
         "use_remote_estimate": "true"      +
     },                                     +
     "server_version": "11.3",              +
     "postgis_version": "2.5.1",            +
     "server_latency_ms": 0.0494956970214844+
 }
(1 row)
```

It takes 10 measurements of TCP connection time to determine latency