### PR TITLE
Federated functions permissions

### DIFF
--- a/scripts-available/CDB_FederatedServer.sql
+++ b/scripts-available/CDB_FederatedServer.sql
@@ -362,6 +362,8 @@ LANGUAGE PLPGSQL IMMUTABLE PARALLEL SAFE;
 
 --
 -- Grant access to a server
+-- In the future we might consider adding the server's view schema to the role search_path
+-- to make it easier to access the created views
 --
 CREATE OR REPLACE FUNCTION @extschema@.CDB_Federated_Server_Grant_Access(server TEXT, db_role NAME)
 RETURNS void

--- a/scripts-available/CDB_FederatedServer.sql
+++ b/scripts-available/CDB_FederatedServer.sql
@@ -238,8 +238,14 @@ BEGIN
                 EXECUTE FORMAT('CREATE ROLE %I NOLOGIN', role_name);
             END IF;
             EXECUTE FORMAT('GRANT ALL PRIVILEGES ON DATABASE %I TO %I', current_database(), role_name);
-            EXECUTE FORMAT('GRANT ALL ON SCHEMA %I TO %I', '@extschema@', role_name);
-            EXECUTE FORMAT('GRANT EXECUTE ON ALL FUNCTIONS in SCHEMA %I TO %I', '@extschema@', role_name);
+
+            EXECUTE FORMAT('GRANT USAGE ON SCHEMA %I TO %I', '@extschema@', role_name);
+            EXECUTE FORMAT('GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA %I TO %I', '@extschema@', role_name);
+
+            EXECUTE FORMAT('GRANT USAGE ON SCHEMA %I TO %I', '@postgisschema@', role_name);
+            EXECUTE FORMAT('GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA %I TO %I', '@postgisschema@', role_name);
+            EXECUTE FORMAT('GRANT SELECT ON ALL TABLES IN SCHEMA %I TO %I', '@postgisschema@', role_name);
+
             EXECUTE FORMAT('GRANT USAGE ON FOREIGN DATA WRAPPER postgres_fdw TO %I', role_name);
             EXECUTE FORMAT('GRANT USAGE ON FOREIGN DATA WRAPPER postgres_fdw TO %I', role_name);
             EXECUTE FORMAT('GRANT USAGE ON FOREIGN SERVER %I TO %I', server_internal, role_name);

--- a/scripts-available/CDB_FederatedServer.sql
+++ b/scripts-available/CDB_FederatedServer.sql
@@ -238,10 +238,6 @@ BEGIN
     IF NOT EXISTS (SELECT * FROM pg_foreign_server WHERE srvname = server_internal) THEN
         BEGIN
             EXECUTE FORMAT('CREATE SERVER %I FOREIGN DATA WRAPPER postgres_fdw', server_internal);
-            -- TODO: Delete this IF before merging to make sure nobody creates a role
-            -- that is later used automatically by us granting them all permissions in the foreign server
-            -- TODO: This is here to help debugging during development (so failures to destroy objects are allowed)
-            -- TODO
             IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = role_name) THEN
                 EXECUTE FORMAT('CREATE ROLE %I NOLOGIN', role_name);
             END IF;

--- a/scripts-available/CDB_FederatedServer.sql
+++ b/scripts-available/CDB_FederatedServer.sql
@@ -301,7 +301,7 @@ BEGIN
     SET client_min_messages = ERROR;
     BEGIN
         EXECUTE FORMAT ('DROP USER MAPPING FOR PUBLIC SERVER %I', server_internal);
-        EXECUTE FORMAT ('DROP OWNED BY %I', role_name);
+        EXECUTE FORMAT ('DROP OWNED BY %I CASCADE', role_name);
         EXECUTE FORMAT ('DROP ROLE %I', role_name);
     EXCEPTION WHEN OTHERS THEN
         RAISE EXCEPTION 'Not enough permissions to drop the server "%"', server;

--- a/scripts-available/CDB_FederatedServer.sql
+++ b/scripts-available/CDB_FederatedServer.sql
@@ -5,9 +5,16 @@
 --
 -- This function is just a placement to store and use the pattern for
 -- foreign object names
--- Servers:     cdb_fs_$(server_name)
--- Schemas:     cdb_fs_schema_$(md5sum(server_name || remote_schema_name))
--- Owner role:  cdb_fs_$(md5sum(current_database() || server_name)
+-- Servers:         cdb_fs_$(server_name)
+-- View schema:     cdb_fs_$(server_name)
+--  > This is where all views created when importing tables are placed
+--  > One server has only one view schema
+-- Import Schemas:  cdb_fs_schema_$(md5sum(server_name || remote_schema_name))
+--  > This is where the foreign tables are placed
+--  > One server has one import schema per remote schema plus auxiliar ones used
+--      to access the remote catalog (pg_catalog, information_schema...)
+-- Owner role:      cdb_fs_$(md5sum(current_database() || server_name)
+--  > This is the role than owns all schemas and tables related to the server
 --
 CREATE OR REPLACE FUNCTION @extschema@.__CDB_FS_Name_Pattern()
 RETURNS TEXT
@@ -19,6 +26,7 @@ LANGUAGE SQL IMMUTABLE PARALLEL SAFE;
 --
 -- Produce a valid DB name for servers generated for the Federated Server
 -- If check_existence is true, it'll throw if the server doesn't exists
+-- This name is also used to
 --
 CREATE OR REPLACE FUNCTION @extschema@.__CDB_FS_Generate_Server_Name(input_name TEXT, check_existence BOOL)
 RETURNS NAME

--- a/scripts-available/CDB_FederatedServer.sql
+++ b/scripts-available/CDB_FederatedServer.sql
@@ -309,7 +309,7 @@ BEGIN
     SET client_min_messages = ERROR;
     BEGIN
         EXECUTE FORMAT ('DROP USER MAPPING FOR PUBLIC SERVER %I', server_internal);
-        EXECUTE FORMAT ('DROP OWNED BY %I CASCADE', role_name);
+        EXECUTE FORMAT ('DROP OWNED BY %I', role_name);
         EXECUTE FORMAT ('DROP ROLE %I', role_name);
     EXCEPTION WHEN OTHERS THEN
         RAISE EXCEPTION 'Not enough permissions to drop the server "%"', server;

--- a/scripts-available/CDB_FederatedServer.sql
+++ b/scripts-available/CDB_FederatedServer.sql
@@ -26,7 +26,7 @@ LANGUAGE SQL IMMUTABLE PARALLEL SAFE;
 --
 -- Produce a valid DB name for servers generated for the Federated Server
 -- If check_existence is true, it'll throw if the server doesn't exists
--- This name is also used to
+-- This name is also used as the schema to store views
 --
 CREATE OR REPLACE FUNCTION @extschema@.__CDB_FS_Generate_Server_Name(input_name TEXT, check_existence BOOL)
 RETURNS NAME
@@ -243,9 +243,10 @@ BEGIN
             END IF;
             EXECUTE FORMAT('GRANT ALL PRIVILEGES ON DATABASE %I TO %I', current_database(), role_name);
 
+            -- These grants over `@extschema@` and `@postgisschema@` are necessary for the cases
+            -- where the schemas aren't accessible to PUBLIC, which is what happens in a CARTO database
             EXECUTE FORMAT('GRANT USAGE ON SCHEMA %I TO %I', '@extschema@', role_name);
             EXECUTE FORMAT('GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA %I TO %I', '@extschema@', role_name);
-
             EXECUTE FORMAT('GRANT USAGE ON SCHEMA %I TO %I', '@postgisschema@', role_name);
             EXECUTE FORMAT('GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA %I TO %I', '@postgisschema@', role_name);
             EXECUTE FORMAT('GRANT SELECT ON ALL TABLES IN SCHEMA %I TO %I', '@postgisschema@', role_name);

--- a/scripts-available/CDB_FederatedServer.sql
+++ b/scripts-available/CDB_FederatedServer.sql
@@ -250,7 +250,7 @@ BEGIN
             EXECUTE FORMAT('GRANT USAGE ON FOREIGN DATA WRAPPER postgres_fdw TO %I', role_name);
             EXECUTE FORMAT('GRANT USAGE ON FOREIGN SERVER %I TO %I', server_internal, role_name);
             EXECUTE FORMAT('ALTER SERVER %I OWNER TO %I', server_internal, role_name);
-            EXECUTE FORMAT ('CREATE USER MAPPING FOR %I SERVER %I', role_name, server_internal);
+            EXECUTE FORMAT ('CREATE USER MAPPING FOR PUBLIC SERVER %I', server_internal);
         EXCEPTION WHEN OTHERS THEN
             RAISE EXCEPTION 'Could not create server %: %', server, SQLERRM
                 USING HINT = 'Please clean the left over objects';
@@ -276,12 +276,12 @@ BEGIN
     LOOP
         IF NOT EXISTS (
             WITH a AS (
-                SELECT split_part(unnest(umoptions), '=', 1) as options from pg_user_mappings WHERE srvname = server_internal AND usename = role_name
+                SELECT split_part(unnest(umoptions), '=', 1) as options from pg_user_mappings WHERE srvname = server_internal AND usename = 'public'
             ) SELECT * from a where options = option.key)
         THEN
-            EXECUTE FORMAT('ALTER USER MAPPING FOR %I SERVER %I OPTIONS (ADD %I %L)', role_name, server_internal, option.key, option.value);
+            EXECUTE FORMAT('ALTER USER MAPPING FOR PUBLIC SERVER %I OPTIONS (ADD %I %L)', server_internal, option.key, option.value);
         ELSE
-            EXECUTE FORMAT('ALTER USER MAPPING FOR %I SERVER %I OPTIONS (SET %I %L)', role_name, server_internal, option.key, option.value);
+            EXECUTE FORMAT('ALTER USER MAPPING FOR PUBLIC SERVER %I OPTIONS (SET %I %L)', server_internal, option.key, option.value);
         END IF;
     END LOOP;
 END
@@ -300,7 +300,7 @@ DECLARE
 BEGIN
     SET client_min_messages = ERROR;
     BEGIN
-        EXECUTE FORMAT ('DROP USER MAPPING FOR %I SERVER %I', role_name, server_internal);
+        EXECUTE FORMAT ('DROP USER MAPPING FOR PUBLIC SERVER %I', server_internal);
         EXECUTE FORMAT ('DROP OWNED BY %I', role_name);
         EXECUTE FORMAT ('DROP ROLE %I', role_name);
     EXCEPTION WHEN OTHERS THEN

--- a/scripts-available/CDB_FederatedServerTables.sql
+++ b/scripts-available/CDB_FederatedServerTables.sql
@@ -311,7 +311,8 @@ BEGIN
                     local_name,
                     cartodb.__CDB_FS_Generate_Server_Role_Name(server_internal));
     EXCEPTION WHEN OTHERS THEN
-        RAISE WARNING 'View "%" could not be shared with other users: %', local_name, SQLERRM;
+        RAISE WARNING 'View "%" could not be shared with other users: %. Execute "ALTER VIEW %1$I OWNER TO %I" to share it',
+                local_name, SQLERRM, local_name, cartodb.__CDB_FS_Generate_Server_Role_Name(server_internal);
     END;
 END
 $$

--- a/scripts-available/CDB_FederatedServerTables.sql
+++ b/scripts-available/CDB_FederatedServerTables.sql
@@ -173,6 +173,8 @@ LANGUAGE PLPGSQL VOLATILE PARALLEL UNSAFE;
 -- can be used through SQL and Maps API's.
 -- If the table was already exported, it will be dropped and re-imported
 --
+-- The view is placed under the server's view schema (cdb_fs_$(server_name))
+--
 -- E.g:
 -- SELECT cartodb.CDB_SetUp_PG_Federated_Table(
 --   'amazon',                  -- mandatory, name of the federated server
@@ -198,7 +200,10 @@ AS $$
 DECLARE
     server_internal name := @extschema@.__CDB_FS_Generate_Server_Name(input_name => server, check_existence => false);
     local_schema name := @extschema@.__CDB_FS_Create_Schema(server_internal, remote_schema);
-    src_table REGCLASS;
+    role_name name := @extschema@.__CDB_FS_Generate_Server_Role_Name(server_internal);
+
+    src_table REGCLASS; -- import_schema.remote_table  - import_schema is local_schema
+    local_view text;    -- view_schema.local_name      - view_schema is server_internal
 
     rest_of_cols TEXT[];
     geom_expression TEXT;
@@ -284,35 +289,27 @@ BEGIN
         webmercator_expression
     ];
 
-    -- To create the view we switch to the caller role to make sure we have permissions
-    -- to write in the destination schema
-    RESET ROLE;
+    -- Create view schema if it doesn't exist
+    IF NOT EXISTS (SELECT oid FROM pg_namespace WHERE nspname = server_internal) THEN
+        EXECUTE 'CREATE SCHEMA ' || quote_ident(server_internal) || ' AUTHORIZATION ' || quote_ident(role_name);
+    END IF;
 
     -- Create a view with homogeneous CDB fields
     BEGIN
         EXECUTE format(
-            'CREATE OR REPLACE VIEW %1$I AS
-                SELECT %2s
-                FROM %3$s t',
-            local_name,
+            'CREATE OR REPLACE VIEW %1$I.%2$I AS
+                SELECT %3s
+                FROM %4$s t',
+            server_internal, local_name,
             array_to_string(carto_columns_expression || rest_of_cols, ','),
             src_table
         );
     EXCEPTION WHEN OTHERS THEN
-        IF EXISTS (SELECT to_regclass(local_name)) THEN
-            RAISE EXCEPTION 'Could not import table "%" as "%" already exists: %', remote_table, local_name, SQLERRM;
+        IF EXISTS (SELECT to_regclass(format('%1$I.%2$I', server_internal, local_name))) THEN
+            RAISE EXCEPTION 'Could not import table "%" as "%.%" already exists', remote_table, server_internal, local_name;
         ELSE
             RAISE EXCEPTION 'Could not import table "%" as "%": %', remote_table, local_name, SQLERRM;
         END IF;
-    END;
-
-    BEGIN
-        EXECUTE format('ALTER VIEW %1$I OWNER TO %I',
-                    local_name,
-                    cartodb.__CDB_FS_Generate_Server_Role_Name(server_internal));
-    EXCEPTION WHEN OTHERS THEN
-        RAISE WARNING 'View "%" could not be shared with other users: %. Execute "ALTER VIEW %1$I OWNER TO %I" to share it',
-                local_name, SQLERRM, local_name, cartodb.__CDB_FS_Generate_Server_Role_Name(server_internal);
     END;
 END
 $$

--- a/scripts-available/CDB_FederatedServerTables.sql
+++ b/scripts-available/CDB_FederatedServerTables.sql
@@ -306,9 +306,13 @@ BEGIN
         END IF;
     END;
 
-    EXECUTE format('ALTER VIEW %1$I OWNER TO %I',
-                local_name,
-                cartodb.__CDB_FS_Generate_Server_Role_Name(server_internal));
+    BEGIN
+        EXECUTE format('ALTER VIEW %1$I OWNER TO %I',
+                    local_name,
+                    cartodb.__CDB_FS_Generate_Server_Role_Name(server_internal));
+    EXCEPTION WHEN OTHERS THEN
+        RAISE WARNING 'View "%" could not be shared with other users: %', local_name, SQLERRM;
+    END;
 END
 $$
 LANGUAGE PLPGSQL VOLATILE PARALLEL UNSAFE;

--- a/test/CDB_FederatedServerTables_expect
+++ b/test/CDB_FederatedServerTables_expect
@@ -3,24 +3,24 @@ C1|
 R1|
 S1|1|POINT(1 1)|patata
 S1|2|POINT(2 2)|patata2
-t|remote_geom|public.remote_geom|id|geom|geom|[{"Name" : "another_field", "Type" : "text"}, {"Name" : "geom", "Type" : "GEOMETRY,4326"}, {"Name" : "id", "Type" : "integer"}]
+t|remote_geom|cdb_fs_loopback.remote_geom|id|geom|geom|[{"Name" : "another_field", "Type" : "text"}, {"Name" : "geom", "Type" : "GEOMETRY,4326"}, {"Name" : "id", "Type" : "integer"}]
 f|remote_geom2|||||[{"Name" : "another_field", "Type" : "text"}, {"Name" : "geom", "Type" : "GEOMETRY,4326"}, {"Name" : "geom_mercator", "Type" : "GEOMETRY,3857"}, {"Name" : "id", "Type" : "bigint"}]
 f|remote_other|||||[{"Name" : "field", "Type" : "text"}, {"Name" : "field2", "Type" : "text"}, {"Name" : "id", "Type" : "bigint"}]
 ## Registering another existing table works
 R2|
 S2|3|POINT(3 3)|patata
-t|remote_geom|public.remote_geom|id|geom|geom|[{"Name" : "another_field", "Type" : "text"}, {"Name" : "geom", "Type" : "GEOMETRY,4326"}, {"Name" : "id", "Type" : "integer"}]
-t|remote_geom2|public."myFullTable"|id|geom|geom_mercator|[{"Name" : "another_field", "Type" : "text"}, {"Name" : "geom", "Type" : "GEOMETRY,4326"}, {"Name" : "geom_mercator", "Type" : "GEOMETRY,3857"}, {"Name" : "id", "Type" : "bigint"}]
+t|remote_geom|cdb_fs_loopback.remote_geom|id|geom|geom|[{"Name" : "another_field", "Type" : "text"}, {"Name" : "geom", "Type" : "GEOMETRY,4326"}, {"Name" : "id", "Type" : "integer"}]
+t|remote_geom2|cdb_fs_loopback."myFullTable"|id|geom|geom_mercator|[{"Name" : "another_field", "Type" : "text"}, {"Name" : "geom", "Type" : "GEOMETRY,4326"}, {"Name" : "geom_mercator", "Type" : "GEOMETRY,3857"}, {"Name" : "id", "Type" : "bigint"}]
 f|remote_other|||||[{"Name" : "field", "Type" : "text"}, {"Name" : "field2", "Type" : "text"}, {"Name" : "id", "Type" : "bigint"}]
 ## Re-registering a table works
 R3|
-ERROR:  relation "myFullTable" does not exist at character 49
+ERROR:  relation "cdb_fs_loopback.myFullTable" does not exist at character 49
 S3_new|3|patata
 ## Unregistering works
 U1|
 ERROR:  relation "remote_geom" does not exist at character 71
 f|remote_geom|||||[{"Name" : "another_field", "Type" : "text"}, {"Name" : "geom", "Type" : "GEOMETRY,4326"}, {"Name" : "id", "Type" : "integer"}]
-t|remote_geom2|public.different_name|id|geom_mercator|geom|[{"Name" : "another_field", "Type" : "text"}, {"Name" : "geom", "Type" : "GEOMETRY,4326"}, {"Name" : "geom_mercator", "Type" : "GEOMETRY,3857"}, {"Name" : "id", "Type" : "bigint"}]
+t|remote_geom2|cdb_fs_loopback.different_name|id|geom_mercator|geom|[{"Name" : "another_field", "Type" : "text"}, {"Name" : "geom", "Type" : "GEOMETRY,4326"}, {"Name" : "geom_mercator", "Type" : "GEOMETRY,3857"}, {"Name" : "id", "Type" : "bigint"}]
 f|remote_other|||||[{"Name" : "field", "Type" : "text"}, {"Name" : "field2", "Type" : "text"}, {"Name" : "id", "Type" : "bigint"}]
 ## Registering a table: Invalid server fails
 ERROR:  Server "Does not exist" does not exist
@@ -50,15 +50,17 @@ ERROR:  non geometry column "Does not exists"
 
 ## Target conflict is handled nicely: Table
 CREATE TABLE
-ERROR:  Could not import table "remote_geom" as "localtable" already exists: "localtable" is not a view
+ERROR:  Could not import table "remote_geom" as "cdb_fs_loopback.localtable" already exists
 ## Target conflict is handled nicely: View
 CREATE VIEW
-ERROR:  Could not import table "remote_geom" as "localtable2" already exists: cannot change name of view column "a" to "cartodb_id"
+ERROR:  Could not import table "remote_geom" as "cdb_fs_loopback.localtable2" already exists
 DROP VIEW
 DROP TABLE
 ## Registering tables does not work without permissions
 You are now connected to database "contrib_regression" as user "cdb_fs_tester".
 ERROR:  Not enough permissions to access the server "loopback"
+## Normal users can not write in the import schema
+ERROR:  permission denied for schema cdb_fs_loopback at character 14
 ## Listing remote tables does not work without permissions
 ERROR:  Not enough permissions to access the server "loopback"
 ## Registering tables works with granted permissions
@@ -67,8 +69,8 @@ You are now connected to database "contrib_regression" as user "postgres".
 You are now connected to database "contrib_regression" as user "cdb_fs_tester".
 
 ## Listing remote tables works with granted permissions
-t|remote_geom|public.localtable|id|geom|geom|[{"Name" : "another_field", "Type" : "text"}, {"Name" : "geom", "Type" : "GEOMETRY,4326"}, {"Name" : "id", "Type" : "integer"}]
-t|remote_geom2|public.different_name|id|geom_mercator|geom|[{"Name" : "another_field", "Type" : "text"}, {"Name" : "geom", "Type" : "GEOMETRY,4326"}, {"Name" : "geom_mercator", "Type" : "GEOMETRY,3857"}, {"Name" : "id", "Type" : "bigint"}]
+t|remote_geom|cdb_fs_loopback.localtable|id|geom|geom|[{"Name" : "another_field", "Type" : "text"}, {"Name" : "geom", "Type" : "GEOMETRY,4326"}, {"Name" : "id", "Type" : "integer"}]
+t|remote_geom2|cdb_fs_loopback.different_name|id|geom_mercator|geom|[{"Name" : "another_field", "Type" : "text"}, {"Name" : "geom", "Type" : "GEOMETRY,4326"}, {"Name" : "geom_mercator", "Type" : "GEOMETRY,3857"}, {"Name" : "id", "Type" : "bigint"}]
 f|remote_other|||||[{"Name" : "field", "Type" : "text"}, {"Name" : "field2", "Type" : "text"}, {"Name" : "id", "Type" : "bigint"}]
 ## Selecting from a registered table with granted permissions works
 1|POINT(1 1)
@@ -86,16 +88,16 @@ ERROR:  You do not have rights to grant access on "loopback"
 You are now connected to database "contrib_regression" as user "postgres".
 
 You are now connected to database "contrib_regression" as user "cdb_fs_tester2".
-t|remote_geom|public.localtable|id|geom|geom|[{"Name" : "another_field", "Type" : "text"}, {"Name" : "geom", "Type" : "GEOMETRY,4326"}, {"Name" : "id", "Type" : "integer"}]
-t|remote_geom2|public.different_name|id|geom_mercator|geom|[{"Name" : "another_field", "Type" : "text"}, {"Name" : "geom", "Type" : "GEOMETRY,4326"}, {"Name" : "geom_mercator", "Type" : "GEOMETRY,3857"}, {"Name" : "id", "Type" : "bigint"}]
+t|remote_geom|cdb_fs_loopback.localtable|id|geom|geom|[{"Name" : "another_field", "Type" : "text"}, {"Name" : "geom", "Type" : "GEOMETRY,4326"}, {"Name" : "id", "Type" : "integer"}]
+t|remote_geom2|cdb_fs_loopback.different_name|id|geom_mercator|geom|[{"Name" : "another_field", "Type" : "text"}, {"Name" : "geom", "Type" : "GEOMETRY,4326"}, {"Name" : "geom_mercator", "Type" : "GEOMETRY,3857"}, {"Name" : "id", "Type" : "bigint"}]
 f|remote_other|||||[{"Name" : "field", "Type" : "text"}, {"Name" : "field2", "Type" : "text"}, {"Name" : "id", "Type" : "bigint"}]
 1|POINT(1 1)
 2|POINT(2 2)
 ## A different user can unregister a table
-NOTICE:  drop cascades to view localtable
+NOTICE:  drop cascades to view cdb_fs_loopback.localtable
 
 f|remote_geom|||||[{"Name" : "another_field", "Type" : "text"}, {"Name" : "geom", "Type" : "GEOMETRY,4326"}, {"Name" : "id", "Type" : "integer"}]
-t|remote_geom2|public.different_name|id|geom_mercator|geom|[{"Name" : "another_field", "Type" : "text"}, {"Name" : "geom", "Type" : "GEOMETRY,4326"}, {"Name" : "geom_mercator", "Type" : "GEOMETRY,3857"}, {"Name" : "id", "Type" : "bigint"}]
+t|remote_geom2|cdb_fs_loopback.different_name|id|geom_mercator|geom|[{"Name" : "another_field", "Type" : "text"}, {"Name" : "geom", "Type" : "GEOMETRY,4326"}, {"Name" : "geom_mercator", "Type" : "GEOMETRY,3857"}, {"Name" : "id", "Type" : "bigint"}]
 f|remote_other|||||[{"Name" : "field", "Type" : "text"}, {"Name" : "field2", "Type" : "text"}, {"Name" : "id", "Type" : "bigint"}]
 ## Only the owner can revoke permissions over the server
 ERROR:  You do not have rights to revoke access on "loopback"


### PR DESCRIPTION
2 changes:
* Grant internal role explicit access over public and cartodb schemas. This is to work around some builder settings that remove permissions over those schemas to public.
* All views are now placed in an auxiliary schema:  This is to ensure that the internal role has creation permission over the destination schema.