### PR TITLE
Fix for collation errors when importing catallog tables

### DIFF
--- a/scripts-available/CDB_FederatedServerDiagnostics.sql
+++ b/scripts-available/CDB_FederatedServerDiagnostics.sql
@@ -16,7 +16,7 @@ BEGIN
         WHERE relnamespace = (SELECT oid FROM pg_namespace WHERE nspname = local_schema)
         AND relname = remote_table
     ) THEN
-        EXECUTE format('IMPORT FOREIGN SCHEMA %I LIMIT TO (%I) FROM SERVER %I INTO %I',
+        EXECUTE format(E'IMPORT FOREIGN SCHEMA %I LIMIT TO (%I) FROM SERVER %I INTO %I OPTIONS (import_collate \'false\')',
                     remote_schema, remote_table, server_internal, local_schema);
     END IF;
 END

--- a/scripts-available/CDB_FederatedServerListRemote.sql
+++ b/scripts-available/CDB_FederatedServerListRemote.sql
@@ -159,7 +159,7 @@ BEGIN
         WHERE relnamespace = (SELECT oid FROM pg_namespace WHERE nspname = local_schema)
         AND relname = remote_geometry_view
     ) THEN
-        EXECUTE format('IMPORT FOREIGN SCHEMA %I LIMIT TO (%I, %I) FROM SERVER %I INTO %I',
+        EXECUTE format(E'IMPORT FOREIGN SCHEMA %I LIMIT TO (%I, %I) FROM SERVER %I INTO %I OPTIONS (import_collate \'false\')',
                     postgis_schema, remote_geometry_view, remote_geography_view, server_internal, local_schema);
     END IF;
 


### PR DESCRIPTION
This fixes #393 by avoiding collation options. The affected function
is only used from diagnostics, and aside from `pg_extension` only
meant to import other catallog tables for internal
diagnostics (`pg_catalog` and `pg_settings`) so it shall be pretty
safe.