### PR TITLE
Change `__CDB_RegenerateTable_Get_Commands` to use the caller timeout or '1min' if not set

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,5 @@
-0.38.0 (XXXX-XX-XX)
+0.37.1 (2020-12-02)
+* Change `__CDB_RegenerateTable_Get_Commands` to use the caller timeout or '1min' if not set.
 
 0.37.0 (2020-11-26)
 * Raised minimum PG version to 11.

--- a/scripts-available/CDB_RegenerateTable.sql
+++ b/scripts-available/CDB_RegenerateTable.sql
@@ -8,6 +8,12 @@ AS $$
     import subprocess
     import re
 
+    query = "SELECT current_setting('statement_timeout') as t"
+    rv = plpy.execute(query, 1)
+    timeout_string = str(rv[0]['t'])
+    if timeout_string == "0":
+        timeout_string = "1min"
+
     query = "SELECT current_database()::text as dname"
     rv = plpy.execute(query, 1)
     database_name_string = str(rv[0]['dname'])
@@ -22,7 +28,7 @@ AS $$
 
     # NOTE: We always use -s so data is never dumped!
     # That would be a security issue that we would need to deal with (and we currently do not need it)
-    process_parameters = ["pg_dump", "-s", "--lock-wait-timeout", "1000", "-t", full_tablename_string, database_name_string]
+    process_parameters = ["pg_dump", "-s", "--lock-wait-timeout", timeout_string, "-t", full_tablename_string, database_name_string]
 
     proc = subprocess.Popen(process_parameters, stdout=subprocess.PIPE, shell=False)
     (out, err) = proc.communicate()

--- a/test/CDB_RegenerateTable.sql
+++ b/test/CDB_RegenerateTable.sql
@@ -244,6 +244,7 @@ ORDER BY pg_catalog.pg_get_expr(c.relpartbound, c.oid) = 'DEFAULT', c.oid::pg_ca
 SELECT cartodb.CDB_GetTableQueries_TestHelper('measurement'::regclass::oid, ignore_cartodbfication := false);
 
 \echo '## Test transaction with truncate'
+SET statement_timeout = 1000;
 BEGIN;
     TRUNCATE TABLE testtable;
     SELECT CDB_RegenerateTable('public.testtable'::regclass);

--- a/test/CDB_RegenerateTable_expect
+++ b/test/CDB_RegenerateTable_expect
@@ -179,6 +179,7 @@ peaktemp|integer|||
 unitsales|integer|||
 ERROR:  CDB_GetTableQueries does not support the parent of partitioned tables
 ## Test transaction with truncate
+SET
 BEGIN
 TRUNCATE TABLE
 ERROR:  plpy.Error: Could not get table properties


### PR DESCRIPTION
Raise the timeout to get the lock to whatever the current `statement_timeout` for the user is. To avoid blocking indefinitely, if the timeout is 0, use 1 minute instead. 