### PR TITLE
[sc161683] Update CDB_TableMetadata_Trigger to handle race conditions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # cartodb/Makefile
 
 EXTENSION = cartodb
-EXTVERSION = 0.37.1
+EXTVERSION = 0.37.2
 
 SED = sed
 AWK = awk
@@ -110,6 +110,7 @@ UPGRADABLE = \
   0.35.0 \
   0.36.0 \
   0.37.0 \
+  0.37.1 \
   $(EXTVERSION)dev \
   $(EXTVERSION)next \
   $(END)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+0.37.2 (2021-09-27)
+* Change `CDB_TableMetadata_Trigger` to handle a race condition due to concurrent inserts.
+
 0.37.1 (2020-12-02)
 * Change `__CDB_RegenerateTable_Get_Commands` to use the caller timeout or '1min' if not set.
 

--- a/scripts-available/CDB_TableMetadata.sql
+++ b/scripts-available/CDB_TableMetadata.sql
@@ -50,7 +50,7 @@ BEGIN
       FROM nv WHERE x.tabname = nv.tabname
       RETURNING x.tabname
     )
-    INSERT INTO @extschema@.CDB_TableMetadata SELECT CONCAT(pg_sleep(2)::text, 'public.points'), nv.t
+    INSERT INTO @extschema@.CDB_TableMetadata SELECT nv.*
     FROM nv LEFT JOIN updated USING(tabname)
     WHERE updated.tabname IS NULL;
   EXCEPTION


### PR DESCRIPTION
### Resources

- [Shortcut story](https://app.shortcut.com/cartoteam/story/161683)

### Context

- When a cartodified table is updated, the following code is triggered in order to log into `cdb_tablemetadata` the name of the table and the last time it was updated:
```sql
    WITH nv as (
      SELECT TG_RELID as tabname, now() as t
    ), updated as (
      UPDATE @extschema@.CDB_TableMetadata x SET updated_at = nv.t
      FROM nv WHERE x.tabname = nv.tabname
      RETURNING x.tabname
    )
    INSERT INTO @extschema@.CDB_TableMetadata SELECT nv.* 
    FROM nv LEFT JOIN updated USING(tabname)
    WHERE updated.tabname IS NULL;
```
- What we are doing in that code is checking if the row already exists and update it (`updated` section). If that section returns `NULL`, it means that there isn't a row for that table, and we insert a new one. But there is a remote chance of race condition when two inserts are made simultaneously and the row doesn't exist yet: if both inserts try to update the row, they will both try to insert the record into the table. The first one will work, but the second one will fail, since the table's name is the primary key.
- It is suspected that this race of condition is the one inconsistently raising the following error, mainly when there are COPY procedures involved: `duplicate key value violates unique constraint \"cdb_tablemetadata_pkey\"`.

### Changes

- Rescuing `UNIQUE_VIOLATION` exception and retrying the update.